### PR TITLE
FEAT: Add block-based pen interpretation with sub-blocks and variations

### DIFF
--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -6,13 +6,15 @@ import { RichTextEditor } from '@/components/RichTextEditor'
 import { MarkdownPreview } from '@/components/MarkdownPreview'
 import { DrawingPalette } from '@/components/DrawingPalette'
 import { useInputModeContext } from '@/contexts/InputModeContext'
-import { parseBlocks, serializeBlocks, defaultBlocks, nextBlockId } from '@/utils/cardBlocks'
+import { parseBlocks, serializeBlocks, defaultBlocks, nextBlockId, createSubBlockFromStrokes, nextVariationId } from '@/utils/cardBlocks'
 import { hasDrawing } from '@/types/models'
 import type { PenCanvasHandle } from '@/components/PenCanvas'
 import { interpretCanvas, getExtractions, getMeetingNotes, listBoards, getBoardsForCard, setBoardsForCard, writeMeetingNotes } from '@/services/api'
 import { useOnlineContext } from '@/contexts/OnlineContext'
 import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
-import type { Card, Board, ContentBlock, SectionType, StrokeTool, LineStyle, PenStroke } from '@/types/models'
+import type { Card, Board, ContentBlock, SectionType, StrokeTool, LineStyle, PenStroke, SubBlock, SubBlockVariation } from '@/types/models'
+import { SubBlockOverlay } from '@/components/SubBlockOverlay'
+import type { CreateSubBlockData } from '@/components/PenCanvas'
 
 type EditorMode = 'keyboard' | 'pen'
 
@@ -425,6 +427,12 @@ export function CardEditor({ onSave, onCancel, onAutoSave, card }: CardEditorPro
     )
   }, [])
 
+  const handleSubBlocksChange = useCallback((blockId: string, subBlocks: SubBlock[]) => {
+    setBlocks((prev) =>
+      prev.map((b) => (b.id === blockId ? { ...b, subBlocks } : b)),
+    )
+  }, [])
+
   /** Undo the last stroke on the active canvas */
   const handleUndo = useCallback(() => {
     for (const [, handle] of penCanvasRefs.current) {
@@ -536,6 +544,7 @@ export function CardEditor({ onSave, onCancel, onAutoSave, card }: CardEditorPro
               onUndo={handleUndo}
               canUndo={canUndo}
               onStrokeComplete={handleStrokeComplete}
+              onSubBlocksChange={handleSubBlocksChange}
               onToggleFullscreen={() => {
                 // Finalize drawing before toggling so strokes persist across mount/unmount
                 const handle = penCanvasRefs.current.get(block.id)
@@ -685,6 +694,7 @@ interface SectionBlockProps {
   savedInterpretation?: CanvasInterpretation | null
   cardUpdatedAt?: string
   extractionCreatedAt?: string | null
+  onSubBlocksChange?: (blockId: string, subBlocks: SubBlock[]) => void
 }
 
 function SectionBlock({
@@ -711,6 +721,7 @@ function SectionBlock({
   savedInterpretation: initialInterpretation,
   cardUpdatedAt,
   extractionCreatedAt,
+  onSubBlocksChange,
 }: SectionBlockProps) {
   const isHeading = block.type === 'heading'
   const showTextArea = isActive && mode === 'keyboard'
@@ -718,6 +729,140 @@ function SectionBlock({
 
   const [interpreting, setInterpreting] = useState(false)
   const [interpretation, setInterpretation] = useState<CanvasInterpretation | null>(initialInterpretation ?? null)
+
+  // ── Sub-block state ──
+  const [subBlocks, setSubBlocks] = useState<SubBlock[]>(block.subBlocks ?? [])
+  const [selectedSubBlockId, setSelectedSubBlockId] = useState<string | null>(null)
+  const [canvasTransform, setCanvasTransform] = useState({ scale: 1, panX: 0, panY: 0 })
+
+  // Propagate sub-block changes to parent
+  const updateSubBlocks = useCallback((newSubBlocks: SubBlock[]) => {
+    setSubBlocks(newSubBlocks)
+    onSubBlocksChange?.(block.id, newSubBlocks)
+  }, [block.id, onSubBlocksChange])
+
+  const handleCreateSubBlock = useCallback((data: CreateSubBlockData) => {
+    const sb = createSubBlockFromStrokes(data.strokes)
+    updateSubBlocks([...subBlocks, sb])
+    setSelectedSubBlockId(sb.id)
+  }, [subBlocks, updateSubBlocks])
+
+  const handleSubBlockDragMove = useCallback((id: string, x: number, y: number) => {
+    updateSubBlocks(subBlocks.map(sb =>
+      sb.id === id ? { ...sb, x, y } : sb
+    ))
+  }, [subBlocks, updateSubBlocks])
+
+  const handleSubBlockDelete = useCallback((id: string) => {
+    // Re-insert original strokes back into the canvas
+    const sb = subBlocks.find(s => s.id === id)
+    if (sb) {
+      const originalStrokes = sb.variations[0]?.strokes ?? []
+      if (originalStrokes.length > 0) {
+        const handle = penCanvasRefs.current.get(block.id)
+        if (handle) {
+          // Strokes need to be added back — we'll do this through onStrokeComplete
+          // For now, the strokes return to drawingContent via parent update
+        }
+      }
+    }
+    updateSubBlocks(subBlocks.filter(s => s.id !== id))
+    if (selectedSubBlockId === id) setSelectedSubBlockId(null)
+  }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
+
+  const handleSubBlockInterpret = useCallback(async (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => {
+    const sb = subBlocks.find(s => s.id === id)
+    if (!sb) return
+
+    // Get the original strokes to render to an offscreen canvas
+    const strokes = sb.variations[0]?.strokes ?? []
+    if (strokes.length === 0) return
+
+    // Render strokes to offscreen canvas
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const stroke of strokes) {
+      for (const p of stroke.points) {
+        if (p.x < minX) minX = p.x
+        if (p.y < minY) minY = p.y
+        if (p.x > maxX) maxX = p.x
+        if (p.y > maxY) maxY = p.y
+      }
+    }
+    const pad = 20
+    const w = Math.max(maxX - minX + pad * 2, 100)
+    const h = Math.max(maxY - minY + pad * 2, 100)
+    const offscreen = document.createElement('canvas')
+    offscreen.width = w
+    offscreen.height = h
+    const ctx = offscreen.getContext('2d')!
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, w, h)
+    ctx.translate(-minX + pad, -minY + pad)
+    const { drawStroke } = await import('@/utils/strokeRenderer')
+    for (const stroke of strokes) {
+      drawStroke(ctx, stroke)
+    }
+    const dataUrl = offscreen.toDataURL('image/png')
+
+    try {
+      let newVariation: SubBlockVariation
+
+      if (mode === 'readText' || mode === 'interpret') {
+        const interpretMode = mode === 'readText' ? 'readText' : undefined
+        const result = await interpretCanvas(dataUrl, cardId, interpretMode, `${block.id}:${sb.id}`)
+        if (mode === 'readText') {
+          newVariation = {
+            id: nextVariationId(),
+            type: 'readText',
+            markdown: result.text || result.description || '',
+            createdAt: new Date().toISOString(),
+          }
+        } else {
+          newVariation = {
+            id: nextVariationId(),
+            type: 'interpret',
+            interpretation: result,
+            createdAt: new Date().toISOString(),
+          }
+        }
+      } else {
+        const result = await writeMeetingNotes(dataUrl, '', cardId)
+        newVariation = {
+          id: nextVariationId(),
+          type: 'meetingNotes',
+          meetingNotes: result,
+          createdAt: new Date().toISOString(),
+        }
+      }
+
+      // Replace existing variation of same type, or append
+      const updated = subBlocks.map(s => {
+        if (s.id !== id) return s
+        const existingIdx = s.variations.findIndex(v => v.type === newVariation.type)
+        const newVariations = [...s.variations]
+        if (existingIdx >= 0) {
+          newVariations[existingIdx] = newVariation
+        } else {
+          newVariations.push(newVariation)
+        }
+        const newActiveIndex = existingIdx >= 0 ? existingIdx : newVariations.length - 1
+        return { ...s, variations: newVariations, activeVariationIndex: newActiveIndex }
+      })
+      updateSubBlocks(updated)
+    } catch (err) {
+      console.error('Sub-block interpretation failed:', err)
+    }
+  }, [subBlocks, updateSubBlocks, cardId, block.id])
+
+  const handleSubBlockVariationSwitch = useCallback((id: string, index: number) => {
+    updateSubBlocks(subBlocks.map(sb =>
+      sb.id === id ? { ...sb, activeVariationIndex: index } : sb
+    ))
+  }, [subBlocks, updateSubBlocks])
+
+  const handleCanvasTransformChange = useCallback((scale: number, panX: number, panY: number) => {
+    setCanvasTransform({ scale, panX, panY })
+  }, [])
   const [interpretationFromDb, setInterpretationFromDb] = useState(!!initialInterpretation)
   const [interpretError, setInterpretError] = useState<string | null>(null)
   const [drawingModifiedSinceInterpret, setDrawingModifiedSinceInterpret] = useState(false)
@@ -894,7 +1039,7 @@ function SectionBlock({
       {/* Drawing sub-area */}
       {showCanvas && (
         <div className="section-drawing-area">
-          <div className="pen-canvas-wrapper">
+          <div className="pen-canvas-wrapper" style={{ position: 'relative' }}>
             <PenCanvas
               ref={(handle) => registerPenRef(block.id, handle)}
               color={drawingTool.color}
@@ -905,7 +1050,34 @@ function SectionBlock({
               initialStrokes={block.drawingContent}
               onUndoStateChange={onUndoStateChange}
               onStrokeComplete={onStrokeComplete}
+              onCreateSubBlock={handleCreateSubBlock}
+              onTransformChange={handleCanvasTransformChange}
             />
+            {/* Sub-block overlays */}
+            {subBlocks.length > 0 && (
+              <div
+                className="subblock-overlay-container"
+                style={{ position: 'absolute', inset: 0, pointerEvents: 'none', overflow: 'hidden' }}
+              >
+                {subBlocks.map(sb => (
+                  <SubBlockOverlay
+                    key={sb.id}
+                    subBlock={sb}
+                    scale={canvasTransform.scale}
+                    panX={canvasTransform.panX}
+                    panY={canvasTransform.panY}
+                    isCanvasActive={showCanvas}
+                    isSelected={selectedSubBlockId === sb.id}
+                    online={online}
+                    onSelect={() => setSelectedSubBlockId(sb.id)}
+                    onDragMove={handleSubBlockDragMove}
+                    onDelete={handleSubBlockDelete}
+                    onInterpret={handleSubBlockInterpret}
+                    onVariationSwitch={handleSubBlockVariationSwitch}
+                  />
+                ))}
+              </div>
+            )}
             <div className="pen-canvas-quick-tools">
               <button
                 className={`pen-canvas-quick-btn ${drawingTool.tool === 'pen' ? 'active' : ''}`}
@@ -946,12 +1118,38 @@ function SectionBlock({
       )}
 
       {/* Finalized drawing preview */}
-      {hasDrawing(block.drawingContent) && !showCanvas && (
+      {(hasDrawing(block.drawingContent) || subBlocks.length > 0) && !showCanvas && (
         <div className="section-drawing-area">
-          <StrokePreview
-            strokes={block.drawingContent}
-            className={isHeading ? 'block-title-image' : 'block-drawing-image'}
-          />
+          {hasDrawing(block.drawingContent) && (
+            <StrokePreview
+              strokes={block.drawingContent}
+              className={isHeading ? 'block-title-image' : 'block-drawing-image'}
+            />
+          )}
+          {/* Show sub-block previews when canvas is inactive */}
+          {subBlocks.length > 0 && (
+            <div className="subblock-previews">
+              {subBlocks.map(sb => {
+                const activeVar = sb.variations[sb.activeVariationIndex] ?? sb.variations[0]
+                return (
+                  <div key={sb.id} className="subblock-preview-card">
+                    {activeVar.type === 'strokes' && activeVar.strokes ? (
+                      <StrokePreview strokes={activeVar.strokes} className="subblock-preview-strokes" />
+                    ) : activeVar.type === 'readText' && activeVar.markdown ? (
+                      <div className="subblock-preview-text">{activeVar.markdown}</div>
+                    ) : activeVar.type === 'interpret' ? (
+                      <div className="subblock-preview-text">{(activeVar.interpretation as CanvasInterpretation)?.description ?? 'Interpreted'}</div>
+                    ) : (
+                      <div className="subblock-preview-text">Block</div>
+                    )}
+                    {sb.variations.length > 1 && (
+                      <div className="subblock-preview-badge">{sb.variations.length} views</div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
           {isActive && (
             <button
               className="pen-canvas-clear"

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -769,22 +769,6 @@ function SectionBlock({
     if (selectedSubBlockId === id) setSelectedSubBlockId(null)
   }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
 
-  const handleSubBlockEdit = useCallback((id: string) => {
-    const sb = subBlocks.find(s => s.id === id)
-    if (!sb) return
-    // Get the original strokes from variation 0
-    const originalStrokes = sb.variations[0]?.strokes ?? []
-    if (originalStrokes.length > 0) {
-      const handle = penCanvasRefs.current.get(block.id)
-      if (handle) {
-        handle.addStrokes(originalStrokes)
-      }
-    }
-    // Remove the sub-block so user can freely edit the strokes on canvas
-    updateSubBlocks(subBlocks.filter(s => s.id !== id))
-    if (selectedSubBlockId === id) setSelectedSubBlockId(null)
-  }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
-
   /** Intercept a newly drawn stroke: if it falls within a sub-block, route it there instead of the main canvas. */
   const handleStrokeDrawn = useCallback((stroke: PenStroke): boolean => {
     if (subBlocks.length === 0) return false
@@ -1120,7 +1104,6 @@ function SectionBlock({
                     onSelect={() => setSelectedSubBlockId(sb.id)}
                     onDragMove={handleSubBlockDragMove}
                     onDelete={handleSubBlockDelete}
-                    onEdit={handleSubBlockEdit}
                     onInterpret={handleSubBlockInterpret}
                     onVariationSwitch={handleSubBlockVariationSwitch}
                     activeTool={drawingTool.tool}

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -761,11 +761,26 @@ function SectionBlock({
       if (originalStrokes.length > 0) {
         const handle = penCanvasRefs.current.get(block.id)
         if (handle) {
-          // Strokes need to be added back — we'll do this through onStrokeComplete
-          // For now, the strokes return to drawingContent via parent update
+          handle.addStrokes(originalStrokes)
         }
       }
     }
+    updateSubBlocks(subBlocks.filter(s => s.id !== id))
+    if (selectedSubBlockId === id) setSelectedSubBlockId(null)
+  }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
+
+  const handleSubBlockEdit = useCallback((id: string) => {
+    const sb = subBlocks.find(s => s.id === id)
+    if (!sb) return
+    // Get the original strokes from variation 0
+    const originalStrokes = sb.variations[0]?.strokes ?? []
+    if (originalStrokes.length > 0) {
+      const handle = penCanvasRefs.current.get(block.id)
+      if (handle) {
+        handle.addStrokes(originalStrokes)
+      }
+    }
+    // Remove the sub-block so user can freely edit the strokes on canvas
     updateSubBlocks(subBlocks.filter(s => s.id !== id))
     if (selectedSubBlockId === id) setSelectedSubBlockId(null)
   }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
@@ -1072,6 +1087,7 @@ function SectionBlock({
                     onSelect={() => setSelectedSubBlockId(sb.id)}
                     onDragMove={handleSubBlockDragMove}
                     onDelete={handleSubBlockDelete}
+                    onEdit={handleSubBlockEdit}
                     onInterpret={handleSubBlockInterpret}
                     onVariationSwitch={handleSubBlockVariationSwitch}
                   />

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -745,7 +745,9 @@ function SectionBlock({
     const sb = createSubBlockFromStrokes(data.strokes)
     updateSubBlocks([...subBlocks, sb])
     setSelectedSubBlockId(sb.id)
-  }, [subBlocks, updateSubBlocks])
+    // Switch back to pen so user can draw into the new sub-block immediately
+    onToolChange('pen')
+  }, [subBlocks, updateSubBlocks, onToolChange])
 
   const handleSubBlockDragMove = useCallback((id: string, x: number, y: number) => {
     updateSubBlocks(subBlocks.map(sb =>

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -750,34 +750,25 @@ function SectionBlock({
   }, [subBlocks, updateSubBlocks, onToolChange])
 
   const handleSubBlockDragMove = useCallback((id: string, x: number, y: number) => {
-    updateSubBlocks(subBlocks.map(sb => {
-      if (sb.id !== id) return sb
-      const dx = x - sb.x
-      const dy = y - sb.y
-      // Translate stroke points so they stay aligned with the new position
-      const variations = sb.variations.map(v => {
-        if (!v.strokes) return v
-        return {
-          ...v,
-          strokes: v.strokes.map(s => ({
-            ...s,
-            points: s.points.map(p => ({ ...p, x: p.x + dx, y: p.y + dy })),
-          })),
-        }
-      })
-      return { ...sb, x, y, variations }
-    }))
+    // Points are relative to sub-block origin, so just update position
+    updateSubBlocks(subBlocks.map(sb =>
+      sb.id === id ? { ...sb, x, y } : sb
+    ))
   }, [subBlocks, updateSubBlocks])
 
   const handleSubBlockDelete = useCallback((id: string) => {
-    // Re-insert original strokes back into the canvas
+    // Re-insert original strokes back into the canvas (convert relative → absolute)
     const sb = subBlocks.find(s => s.id === id)
     if (sb) {
-      const originalStrokes = sb.variations[0]?.strokes ?? []
-      if (originalStrokes.length > 0) {
+      const relativeStrokes = sb.variations[0]?.strokes ?? []
+      if (relativeStrokes.length > 0) {
         const handle = penCanvasRefs.current.get(block.id)
         if (handle) {
-          handle.addStrokes(originalStrokes)
+          const absoluteStrokes = relativeStrokes.map(s => ({
+            ...s,
+            points: s.points.map(p => ({ ...p, x: p.x + sb.x, y: p.y + sb.y })),
+          }))
+          handle.addStrokes(absoluteStrokes)
         }
       }
     }
@@ -799,15 +790,21 @@ function SectionBlock({
       cy >= sb.y && cy <= sb.y + sb.height
     )
     if (!target) return false
-    // Add stroke to the sub-block's strokes variation and recalculate bounds
+    // Convert stroke points to sub-block-relative coordinates and recalculate bounds
     const updated = subBlocks.map(s => {
       if (s.id !== target.id) return s
+      const relativeStroke = {
+        ...stroke,
+        points: stroke.points.map(p => ({ ...p, x: p.x - s.x, y: p.y - s.y })),
+      }
       const currentStrokes = s.variations[0]?.strokes ?? []
-      const newStrokes = [...currentStrokes, { ...stroke, points: stroke.points.map(p => ({ ...p })) }]
-      const bounds = computeStrokeBounds(newStrokes)
+      const newStrokes = [...currentStrokes, relativeStroke]
+      // Compute new bounds from relative points, then convert back to absolute
+      const relBounds = computeStrokeBounds(newStrokes)
       return {
         ...s,
-        ...bounds,
+        width: relBounds.width,
+        height: relBounds.height,
         variations: s.variations.map((v, i) =>
           i === 0 ? { ...v, strokes: newStrokes } : v
         ),

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo, memo } from 'react'
 import { createPortal } from 'react-dom'
 import { PenCanvas } from '@/components/PenCanvas'
 import { StrokePreview } from '@/components/StrokePreview'
@@ -6,14 +6,14 @@ import { RichTextEditor } from '@/components/RichTextEditor'
 import { MarkdownPreview } from '@/components/MarkdownPreview'
 import { DrawingPalette } from '@/components/DrawingPalette'
 import { useInputModeContext } from '@/contexts/InputModeContext'
-import { parseBlocks, serializeBlocks, defaultBlocks, nextBlockId, createSubBlockFromStrokes, nextVariationId, computeStrokeBounds } from '@/utils/cardBlocks'
+import { parseBlocks, serializeBlocks, defaultBlocks, nextBlockId, createSubBlockFromStrokes, nextVariationId, computeStrokeBounds, nextSubBlockId } from '@/utils/cardBlocks'
 import { hasDrawing } from '@/types/models'
 import type { PenCanvasHandle } from '@/components/PenCanvas'
 import { interpretCanvas, getExtractions, getMeetingNotes, listBoards, getBoardsForCard, setBoardsForCard, writeMeetingNotes } from '@/services/api'
 import { useOnlineContext } from '@/contexts/OnlineContext'
 import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
 import type { Card, Board, ContentBlock, SectionType, StrokeTool, LineStyle, PenStroke, SubBlock, SubBlockVariation } from '@/types/models'
-import { SubBlockOverlay } from '@/components/SubBlockOverlay'
+import { SubBlockOverlay, getSubBlockClipboard, setSubBlockClipboard } from '@/components/SubBlockOverlay'
 import type { CreateSubBlockData } from '@/components/PenCanvas'
 
 type EditorMode = 'keyboard' | 'pen'
@@ -90,16 +90,19 @@ export function CardEditor({ onSave, onCancel, onAutoSave, card }: CardEditorPro
 
   const penCanvasRefs = useRef<Map<string, PenCanvasHandle>>(new Map())
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const blocksRef = useRef(blocks)
+  blocksRef.current = blocks
 
   // ── localStorage draft save/restore for pen drawings ──
   const draftKey = `stonie-pen-draft-${card?.id ?? 'new'}`
+  const draftKeyRef = useRef(draftKey)
+  draftKeyRef.current = draftKey
 
   /** Save current block drawing data to localStorage */
   const saveDraftToLocalStorage = useCallback(() => {
     try {
-      // Gather strokes from all active canvases + stored block data
       const drawingData: Record<string, PenStroke[]> = {}
-      for (const block of blocks) {
+      for (const block of blocksRef.current) {
         const handle = penCanvasRefs.current.get(block.id)
         const strokes = handle?.hasContent() ? handle.getStrokes() : block.drawingContent
         if (strokes && strokes.length > 0) {
@@ -107,14 +110,14 @@ export function CardEditor({ onSave, onCancel, onAutoSave, card }: CardEditorPro
         }
       }
       if (Object.keys(drawingData).length > 0) {
-        localStorage.setItem(draftKey, JSON.stringify(drawingData))
+        localStorage.setItem(draftKeyRef.current, JSON.stringify(drawingData))
       } else {
-        localStorage.removeItem(draftKey)
+        localStorage.removeItem(draftKeyRef.current)
       }
     } catch {
       // localStorage may be full or unavailable — silently ignore
     }
-  }, [blocks, draftKey])
+  }, [])
 
   const clearDraftFromLocalStorage = useCallback(() => {
     try { localStorage.removeItem(draftKey) } catch { /* ignore */ }
@@ -143,10 +146,34 @@ export function CardEditor({ onSave, onCancel, onAutoSave, card }: CardEditorPro
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  /** Called by PenCanvas after each stroke change — triggers localStorage save */
+  /** Called by PenCanvas after each stroke change — debounced localStorage save.
+   *  Saves after 2s of inactivity so drawing isn't blocked by JSON serialization. */
+  const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const handleStrokeComplete = useCallback(() => {
-    saveDraftToLocalStorage()
+    if (draftSaveTimerRef.current !== null) {
+      clearTimeout(draftSaveTimerRef.current)
+    }
+    draftSaveTimerRef.current = setTimeout(() => {
+      draftSaveTimerRef.current = null
+      // Use requestIdleCallback to avoid blocking main thread during drawing
+      if (typeof requestIdleCallback === 'function') {
+        requestIdleCallback(() => saveDraftToLocalStorage())
+      } else {
+        saveDraftToLocalStorage()
+      }
+    }, 2000)
   }, [saveDraftToLocalStorage])
+
+  // Flush pending draft save on unmount
+  useEffect(() => {
+    return () => {
+      if (draftSaveTimerRef.current !== null) {
+        clearTimeout(draftSaveTimerRef.current)
+        saveDraftToLocalStorage()
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Load all boards and current card's board associations
   useEffect(() => {
@@ -668,6 +695,83 @@ export function CardEditor({ onSave, onCancel, onAutoSave, card }: CardEditorPro
   )
 }
 
+/* ── CanvasContextMenu (isolated re-renders) ──── */
+
+type ContextMenuState =
+  | { type: 'lasso'; x: number; y: number }
+  | { type: 'subblock'; x: number; y: number; subBlockId: string }
+  | null
+
+interface CanvasContextMenuProps {
+  menuRef: React.RefObject<ContextMenuState>
+  version: number
+  interpretingSubBlockId: string | null
+  penCanvasRefs: React.RefObject<Map<string, PenCanvasHandle>>
+  blockId: string
+  onSetContextMenu: (val: ContextMenuState) => void
+  onSubBlockInterpret: (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => void
+  onSubBlockCopy: () => void
+  onSubBlockCut: () => void
+  onSubBlockPaste: () => void
+  onSubBlockDelete: (id: string) => void
+}
+
+const CanvasContextMenu = memo(function CanvasContextMenu({
+  menuRef,
+  version,
+  interpretingSubBlockId,
+  penCanvasRefs,
+  blockId,
+  onSetContextMenu,
+  onSubBlockInterpret,
+  onSubBlockCopy,
+  onSubBlockCut,
+  onSubBlockPaste,
+  onSubBlockDelete,
+}: CanvasContextMenuProps) {
+  void version // used to trigger re-renders
+  const cm = menuRef.current
+  if (!cm) return null
+  return (
+    <div
+      className="pen-canvas-context-menu"
+      style={{
+        position: 'absolute',
+        left: cm.x,
+        top: cm.y,
+        zIndex: 100,
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {cm.type === 'lasso' && (() => {
+        const handle = penCanvasRefs.current.get(blockId)
+        return (
+          <>
+            <button type="button" className="pen-canvas-context-item" onClick={() => handle?.copySelection()}>Copy</button>
+            <button type="button" className="pen-canvas-context-item" onClick={() => { handle?.cutSelection(); onSetContextMenu(null) }}>Cut</button>
+            <button type="button" className="pen-canvas-context-item" onClick={() => handle?.pasteStrokes()} disabled={!handle?.canPaste()}>Paste</button>
+            <button type="button" className="pen-canvas-context-item" onClick={() => { handle?.deleteSelection(); onSetContextMenu(null) }}>Delete</button>
+            <button type="button" className="pen-canvas-context-item" onClick={() => { handle?.extractSelection(); onSetContextMenu(null) }}>Create Block</button>
+          </>
+        )
+      })()}
+      {cm.type === 'subblock' && (
+        <>
+          <button type="button" className="pen-canvas-context-item" onClick={() => onSubBlockInterpret(cm.subBlockId, 'readText')} disabled={interpretingSubBlockId === cm.subBlockId}>Read</button>
+          <button type="button" className="pen-canvas-context-item" onClick={() => onSubBlockInterpret(cm.subBlockId, 'interpret')} disabled={interpretingSubBlockId === cm.subBlockId}>Interpret</button>
+          <button type="button" className="pen-canvas-context-item" onClick={() => onSubBlockInterpret(cm.subBlockId, 'meetingNotes')} disabled={interpretingSubBlockId === cm.subBlockId}>Notes</button>
+          <span className="pen-canvas-context-divider" />
+          <button type="button" className="pen-canvas-context-item" onClick={() => onSubBlockCopy()}>Copy</button>
+          <button type="button" className="pen-canvas-context-item" onClick={() => onSubBlockCut()}>Cut</button>
+          <button type="button" className="pen-canvas-context-item" onClick={() => onSubBlockPaste()}>Paste</button>
+          <span className="pen-canvas-context-divider" />
+          <button type="button" className="pen-canvas-context-item pen-canvas-context-danger" onClick={() => onSubBlockDelete(cm.subBlockId)}>Delete</button>
+        </>
+      )}
+    </div>
+  )
+})
+
 /* ── SectionBlock ─────────────────────────────── */
 
 interface SectionBlockProps {
@@ -732,8 +836,36 @@ function SectionBlock({
 
   // ── Sub-block state ──
   const [subBlocks, setSubBlocks] = useState<SubBlock[]>(block.subBlocks ?? [])
+  const subBlocksRef = useRef(subBlocks)
+  subBlocksRef.current = subBlocks
   const [selectedSubBlockId, setSelectedSubBlockId] = useState<string | null>(null)
-  const [canvasTransform, setCanvasTransform] = useState({ scale: 1, panX: 0, panY: 0 })
+  const selectedSubBlockIdRef = useRef(selectedSubBlockId)
+  selectedSubBlockIdRef.current = selectedSubBlockId
+  const canvasTransformRef = useRef({ scale: 1, panX: 0, panY: 0 })
+  const overlayContainerRef = useRef<HTMLDivElement>(null)
+  const [canvasTransformVersion, setCanvasTransformVersion] = useState(0)
+  const transformRafRef = useRef<number | null>(null)
+  const [interpretingSubBlockId, setInterpretingSubBlockId] = useState<string | null>(null)
+
+  // ── Unified context menu (lasso selection or sub-block) ──
+  // Stored in a ref to avoid re-rendering PenCanvas on menu changes.
+  // A version counter triggers re-render of only the CanvasContextMenu component.
+  const contextMenuRef = useRef<ContextMenuState>(null)
+  const [contextMenuVersion, setContextMenuVersion] = useState(0)
+  const setContextMenu = useCallback((val: ContextMenuState | ((prev: ContextMenuState) => ContextMenuState)) => {
+    if (typeof val === 'function') {
+      contextMenuRef.current = val(contextMenuRef.current)
+    } else {
+      contextMenuRef.current = val
+    }
+    setContextMenuVersion(v => v + 1)
+  }, [])
+
+  // Sub-block undo stack for draw-into and erase-from operations
+  type SubBlockUndoAction =
+    | { type: 'addStroke'; subBlockId: string; strokeIndex: number }
+    | { type: 'eraseStroke'; subBlockId: string; stroke: PenStroke; strokeIndex: number }
+  const subBlockUndoRef = useRef<SubBlockUndoAction[]>([])
 
   // Propagate sub-block changes to parent
   const updateSubBlocks = useCallback((newSubBlocks: SubBlock[]) => {
@@ -741,24 +873,84 @@ function SectionBlock({
     onSubBlocksChange?.(block.id, newSubBlocks)
   }, [block.id, onSubBlocksChange])
 
+  /** PenCanvas lasso selection context menu callback */
+  const handleSelectionContextMenu = useCallback((pos: { x: number; y: number } | null) => {
+    if (pos) {
+      setSelectedSubBlockId(null)
+      setContextMenu({ type: 'lasso', ...pos })
+    } else {
+      setContextMenu(prev => prev?.type === 'lasso' ? null : prev)
+    }
+  }, [])
+
+  /** Show context menu for a selected sub-block at its right edge */
+  const showSubBlockContextMenu = useCallback((sbId: string) => {
+    const sb = subBlocksRef.current.find(s => s.id === sbId)
+    if (!sb) return
+    const { scale, panX, panY } = canvasTransformRef.current
+    const menuX = (sb.x + sb.width) * scale + panX + 8
+    const menuY = sb.y * scale + panY
+    setContextMenu({ type: 'subblock', x: menuX, y: menuY, subBlockId: sbId })
+  }, [setContextMenu])
+
+  /** Select a sub-block and show its context menu */
+  const handleSubBlockSelect = useCallback((sbId: string) => {
+    setSelectedSubBlockId(sbId)
+    showSubBlockContextMenu(sbId)
+  }, [showSubBlockContextMenu])
+
+  /** Sub-block copy */
+  const handleSubBlockCopy = useCallback(() => {
+    const selId = selectedSubBlockIdRef.current
+    if (!selId) return
+    const sb = subBlocksRef.current.find(s => s.id === selId)
+    if (sb) setSubBlockClipboard(structuredClone(sb))
+  }, [])
+
+  // handleSubBlockCut is defined after handleSubBlockDelete below
+
+  /** Sub-block paste */
+  const handleSubBlockPaste = useCallback(() => {
+    const clip = getSubBlockClipboard()
+    if (!clip) return
+    const cloned = structuredClone(clip)
+    cloned.id = nextSubBlockId()
+    cloned.x += 20
+    cloned.y += 20
+    updateSubBlocks([...subBlocksRef.current, cloned])
+    setSelectedSubBlockId(cloned.id)
+    const { scale, panX, panY } = canvasTransformRef.current
+    const menuX = (cloned.x + cloned.width) * scale + panX + 8
+    const menuY = cloned.y * scale + panY
+    setContextMenu({ type: 'subblock', x: menuX, y: menuY, subBlockId: cloned.id })
+  }, [updateSubBlocks, setContextMenu])
+
   const handleCreateSubBlock = useCallback((data: CreateSubBlockData) => {
     const sb = createSubBlockFromStrokes(data.strokes)
-    updateSubBlocks([...subBlocks, sb])
+    updateSubBlocks([...subBlocksRef.current, sb])
     setSelectedSubBlockId(sb.id)
     // Switch back to pen so user can draw into the new sub-block immediately
     onToolChange('pen')
-  }, [subBlocks, updateSubBlocks, onToolChange])
+  }, [updateSubBlocks, onToolChange])
+
+  /** Remove the most recently created sub-block (called when PenCanvas undoes an extractSubBlock action) */
+  const handleUndoExtractSubBlock = useCallback(() => {
+    const sbs = subBlocksRef.current
+    if (sbs.length === 0) return
+    const removed = sbs[sbs.length - 1]
+    updateSubBlocks(sbs.slice(0, -1))
+    if (selectedSubBlockIdRef.current === removed.id) setSelectedSubBlockId(null)
+  }, [updateSubBlocks])
 
   const handleSubBlockDragMove = useCallback((id: string, x: number, y: number) => {
-    // Points are relative to sub-block origin, so just update position
-    updateSubBlocks(subBlocks.map(sb =>
+    updateSubBlocks(subBlocksRef.current.map(sb =>
       sb.id === id ? { ...sb, x, y } : sb
     ))
-  }, [subBlocks, updateSubBlocks])
+  }, [updateSubBlocks])
 
   const handleSubBlockDelete = useCallback((id: string) => {
-    // Re-insert original strokes back into the canvas (convert relative → absolute)
-    const sb = subBlocks.find(s => s.id === id)
+    const sbs = subBlocksRef.current
+    const sb = sbs.find(s => s.id === id)
     if (sb) {
       const relativeStrokes = sb.variations[0]?.strokes ?? []
       if (relativeStrokes.length > 0) {
@@ -772,34 +964,43 @@ function SectionBlock({
         }
       }
     }
-    updateSubBlocks(subBlocks.filter(s => s.id !== id))
-    if (selectedSubBlockId === id) setSelectedSubBlockId(null)
-  }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
+    updateSubBlocks(sbs.filter(s => s.id !== id))
+    if (selectedSubBlockIdRef.current === id) {
+      setSelectedSubBlockId(null)
+      setContextMenu(null)
+    }
+  }, [updateSubBlocks, setContextMenu, block.id, penCanvasRefs])
+
+  /** Sub-block cut (copy + delete) */
+  const handleSubBlockCut = useCallback(() => {
+    const selId = selectedSubBlockIdRef.current
+    if (!selId) return
+    handleSubBlockCopy()
+    handleSubBlockDelete(selId)
+  }, [handleSubBlockCopy, handleSubBlockDelete])
 
   /** Intercept a newly drawn stroke: if it falls within a sub-block, route it there instead of the main canvas. */
   const handleStrokeDrawn = useCallback((stroke: PenStroke): boolean => {
-    if (subBlocks.length === 0) return false
-    // Compute stroke centroid
+    const sbs = subBlocksRef.current
+    if (sbs.length === 0) return false
     let cx = 0, cy = 0
     for (const p of stroke.points) { cx += p.x; cy += p.y }
     cx /= stroke.points.length
     cy /= stroke.points.length
-    // Find the sub-block whose bounds contain the centroid
-    const target = subBlocks.find(sb =>
+    const target = sbs.find(sb =>
       cx >= sb.x && cx <= sb.x + sb.width &&
       cy >= sb.y && cy <= sb.y + sb.height
     )
     if (!target) return false
-    // Convert stroke points to sub-block-relative coordinates and recalculate bounds
-    const updated = subBlocks.map(s => {
+    const currentStrokes = target.variations[0]?.strokes ?? []
+    const newStrokeIndex = currentStrokes.length
+    const updated = sbs.map(s => {
       if (s.id !== target.id) return s
       const relativeStroke = {
         ...stroke,
         points: stroke.points.map(p => ({ ...p, x: p.x - s.x, y: p.y - s.y })),
       }
-      const currentStrokes = s.variations[0]?.strokes ?? []
       const newStrokes = [...currentStrokes, relativeStroke]
-      // Compute new bounds from relative points, then convert back to absolute
       const relBounds = computeStrokeBounds(newStrokes)
       return {
         ...s,
@@ -810,13 +1011,123 @@ function SectionBlock({
         ),
       }
     })
+    subBlocksRef.current = updated  // Keep ref in sync for immediate reads
     updateSubBlocks(updated)
-    return true // consumed — don't add to main canvas
-  }, [subBlocks, updateSubBlocks])
+    subBlockUndoRef.current.push({ type: 'addStroke', subBlockId: target.id, strokeIndex: newStrokeIndex })
+    onUndoStateChange(true)
+    return true
+  }, [updateSubBlocks, onUndoStateChange])
+
+  /** Point-to-line-segment distance for eraser hit-testing */
+  const distToSegment = useCallback((px: number, py: number, x1: number, y1: number, x2: number, y2: number): number => {
+    const dx = x2 - x1
+    const dy = y2 - y1
+    const lenSq = dx * dx + dy * dy
+    if (lenSq === 0) return Math.hypot(px - x1, py - y1)
+    let t = ((px - x1) * dx + (py - y1) * dy) / lenSq
+    t = Math.max(0, Math.min(1, t))
+    return Math.hypot(px - (x1 + t * dx), py - (y1 + t * dy))
+  }, [])
+
+  /** Erase sub-block strokes at the given logical canvas point */
+  const handleEraseAtPoint = useCallback((x: number, y: number) => {
+    const sbs = subBlocksRef.current
+    if (sbs.length === 0) return
+    const eraserRadius = 12 / canvasTransformRef.current.scale
+    let changed = false
+    const updated = sbs.map(sb => {
+      const strokes = sb.variations[0]?.strokes
+      if (!strokes || strokes.length === 0) return sb
+      const relX = x - sb.x
+      const relY = y - sb.y
+      if (relX < -eraserRadius || relX > sb.width + eraserRadius ||
+          relY < -eraserRadius || relY > sb.height + eraserRadius) return sb
+      const remaining: PenStroke[] = []
+      strokes.forEach((stroke, idx) => {
+        let hit = false
+        for (let i = 1; i < stroke.points.length; i++) {
+          const p0 = stroke.points[i - 1]
+          const p1 = stroke.points[i]
+          const dist = distToSegment(relX, relY, p0.x, p0.y, p1.x, p1.y)
+          if (dist < eraserRadius + stroke.width * 0.75) {
+            hit = true
+            break
+          }
+        }
+        if (hit) {
+          subBlockUndoRef.current.push({ type: 'eraseStroke', subBlockId: sb.id, stroke, strokeIndex: idx })
+          changed = true
+        } else {
+          remaining.push(stroke)
+        }
+      })
+      if (remaining.length === strokes.length) return sb
+      const relBounds = computeStrokeBounds(remaining)
+      return {
+        ...sb,
+        width: remaining.length > 0 ? relBounds.width : sb.width,
+        height: remaining.length > 0 ? relBounds.height : sb.height,
+        variations: sb.variations.map((v, i) =>
+          i === 0 ? { ...v, strokes: remaining } : v
+        ),
+      }
+    })
+    if (changed) {
+      subBlocksRef.current = updated  // Keep ref in sync for subsequent calls in same flush batch
+      updateSubBlocks(updated)
+      onUndoStateChange(true)
+    }
+  }, [distToSegment, updateSubBlocks, onUndoStateChange])
+
+  /** Undo the last sub-block operation (stroke add or erase) */
+  const handleSubBlockUndo = useCallback((): boolean => {
+    const action = subBlockUndoRef.current.pop()
+    if (!action) return false
+    const sbs = subBlocksRef.current
+    if (action.type === 'addStroke') {
+      const updated = sbs.map(sb => {
+        if (sb.id !== action.subBlockId) return sb
+        const strokes = sb.variations[0]?.strokes
+        if (!strokes || strokes.length === 0) return sb
+        const newStrokes = strokes.slice(0, -1)
+        const relBounds = computeStrokeBounds(newStrokes)
+        return {
+          ...sb,
+          width: newStrokes.length > 0 ? relBounds.width : sb.width,
+          height: newStrokes.length > 0 ? relBounds.height : sb.height,
+          variations: sb.variations.map((v, i) =>
+            i === 0 ? { ...v, strokes: newStrokes } : v
+          ),
+        }
+      })
+      subBlocksRef.current = updated
+      updateSubBlocks(updated)
+    } else if (action.type === 'eraseStroke') {
+      const updated = sbs.map(sb => {
+        if (sb.id !== action.subBlockId) return sb
+        const strokes = [...(sb.variations[0]?.strokes ?? [])]
+        strokes.splice(Math.min(action.strokeIndex, strokes.length), 0, action.stroke)
+        const relBounds = computeStrokeBounds(strokes)
+        return {
+          ...sb,
+          width: relBounds.width,
+          height: relBounds.height,
+          variations: sb.variations.map((v, i) =>
+            i === 0 ? { ...v, strokes } : v
+          ),
+        }
+      })
+      subBlocksRef.current = updated
+      updateSubBlocks(updated)
+    }
+    onUndoStateChange(subBlockUndoRef.current.length > 0 || (penCanvasRefs.current.get(block.id)?.canUndo() ?? false))
+    return true
+  }, [updateSubBlocks, onUndoStateChange, block.id, penCanvasRefs])
 
   const handleSubBlockInterpret = useCallback(async (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => {
     const sb = subBlocks.find(s => s.id === id)
     if (!sb) return
+    setInterpretingSubBlockId(id)
 
     // Get the original strokes to render to an offscreen canvas
     const strokes = sb.variations[0]?.strokes ?? []
@@ -895,6 +1206,8 @@ function SectionBlock({
       updateSubBlocks(updated)
     } catch (err) {
       console.error('Sub-block interpretation failed:', err)
+    } finally {
+      setInterpretingSubBlockId(null)
     }
   }, [subBlocks, updateSubBlocks, cardId, block.id])
 
@@ -905,8 +1218,26 @@ function SectionBlock({
   }, [subBlocks, updateSubBlocks])
 
   const handleCanvasTransformChange = useCallback((scale: number, panX: number, panY: number) => {
-    setCanvasTransform({ scale, panX, panY })
+    canvasTransformRef.current = { scale, panX, panY }
+    // Schedule a single React re-render per animation frame for overlays
+    if (transformRafRef.current === null) {
+      transformRafRef.current = requestAnimationFrame(() => {
+        transformRafRef.current = null
+        setCanvasTransformVersion(v => v + 1)
+      })
+    }
   }, [])
+
+  /** Undo: try PenCanvas first, then sub-block undo stack */
+  const handleLocalUndo = useCallback(() => {
+    const handle = penCanvasRefs.current.get(block.id)
+    if (handle?.canUndo()) {
+      handle.undo()
+      return
+    }
+    handleSubBlockUndo()
+  }, [block.id, penCanvasRefs, handleSubBlockUndo])
+
   const [interpretationFromDb, setInterpretationFromDb] = useState(!!initialInterpretation)
   const [interpretError, setInterpretError] = useState<string | null>(null)
   const [drawingModifiedSinceInterpret, setDrawingModifiedSinceInterpret] = useState(false)
@@ -1095,35 +1426,51 @@ function SectionBlock({
               onUndoStateChange={onUndoStateChange}
               onStrokeComplete={onStrokeComplete}
               onCreateSubBlock={handleCreateSubBlock}
+              onUndoExtractSubBlock={handleUndoExtractSubBlock}
               onTransformChange={handleCanvasTransformChange}
               onStrokeDrawn={handleStrokeDrawn}
+              onEraseAtPoint={handleEraseAtPoint}
+              onUndoFallback={handleSubBlockUndo}
+              onSelectionContextMenu={handleSelectionContextMenu}
             />
             {/* Sub-block overlays */}
             {subBlocks.length > 0 && (
               <div
+                ref={overlayContainerRef}
                 className="subblock-overlay-container"
+                data-transform-version={canvasTransformVersion}
                 style={{ position: 'absolute', inset: 0, pointerEvents: 'none', overflow: 'hidden' }}
               >
                 {subBlocks.map(sb => (
                   <SubBlockOverlay
                     key={sb.id}
                     subBlock={sb}
-                    scale={canvasTransform.scale}
-                    panX={canvasTransform.panX}
-                    panY={canvasTransform.panY}
-                    isCanvasActive={showCanvas}
+                    scale={canvasTransformRef.current.scale}
+                    panX={canvasTransformRef.current.panX}
+                    panY={canvasTransformRef.current.panY}
                     isSelected={selectedSubBlockId === sb.id}
-                    online={online}
-                    onSelect={() => setSelectedSubBlockId(sb.id)}
+                    onSelect={() => handleSubBlockSelect(sb.id)}
                     onDragMove={handleSubBlockDragMove}
-                    onDelete={handleSubBlockDelete}
-                    onInterpret={handleSubBlockInterpret}
                     onVariationSwitch={handleSubBlockVariationSwitch}
                     activeTool={drawingTool.tool}
                   />
                 ))}
               </div>
             )}
+            {/* Unified context menu */}
+            <CanvasContextMenu
+              menuRef={contextMenuRef}
+              version={contextMenuVersion}
+              interpretingSubBlockId={interpretingSubBlockId}
+              penCanvasRefs={penCanvasRefs}
+              blockId={block.id}
+              onSetContextMenu={setContextMenu}
+              onSubBlockInterpret={handleSubBlockInterpret}
+              onSubBlockCopy={handleSubBlockCopy}
+              onSubBlockCut={handleSubBlockCut}
+              onSubBlockPaste={handleSubBlockPaste}
+              onSubBlockDelete={handleSubBlockDelete}
+            />
             <div className="pen-canvas-quick-tools">
               <button
                 className={`pen-canvas-quick-btn ${drawingTool.tool === 'pen' ? 'active' : ''}`}
@@ -1151,7 +1498,7 @@ function SectionBlock({
               </button>
               <button
                 className="pen-canvas-quick-btn"
-                onClick={(e) => { e.stopPropagation(); onUndo() }}
+                onClick={(e) => { e.stopPropagation(); handleLocalUndo() }}
                 disabled={!canUndo}
                 title="Undo (Ctrl+Z)"
                 type="button"

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -750,9 +750,23 @@ function SectionBlock({
   }, [subBlocks, updateSubBlocks, onToolChange])
 
   const handleSubBlockDragMove = useCallback((id: string, x: number, y: number) => {
-    updateSubBlocks(subBlocks.map(sb =>
-      sb.id === id ? { ...sb, x, y } : sb
-    ))
+    updateSubBlocks(subBlocks.map(sb => {
+      if (sb.id !== id) return sb
+      const dx = x - sb.x
+      const dy = y - sb.y
+      // Translate stroke points so they stay aligned with the new position
+      const variations = sb.variations.map(v => {
+        if (!v.strokes) return v
+        return {
+          ...v,
+          strokes: v.strokes.map(s => ({
+            ...s,
+            points: s.points.map(p => ({ ...p, x: p.x + dx, y: p.y + dy })),
+          })),
+        }
+      })
+      return { ...sb, x, y, variations }
+    }))
   }, [subBlocks, updateSubBlocks])
 
   const handleSubBlockDelete = useCallback((id: string) => {

--- a/client/src/components/CardEditor.tsx
+++ b/client/src/components/CardEditor.tsx
@@ -6,7 +6,7 @@ import { RichTextEditor } from '@/components/RichTextEditor'
 import { MarkdownPreview } from '@/components/MarkdownPreview'
 import { DrawingPalette } from '@/components/DrawingPalette'
 import { useInputModeContext } from '@/contexts/InputModeContext'
-import { parseBlocks, serializeBlocks, defaultBlocks, nextBlockId, createSubBlockFromStrokes, nextVariationId } from '@/utils/cardBlocks'
+import { parseBlocks, serializeBlocks, defaultBlocks, nextBlockId, createSubBlockFromStrokes, nextVariationId, computeStrokeBounds } from '@/utils/cardBlocks'
 import { hasDrawing } from '@/types/models'
 import type { PenCanvasHandle } from '@/components/PenCanvas'
 import { interpretCanvas, getExtractions, getMeetingNotes, listBoards, getBoardsForCard, setBoardsForCard, writeMeetingNotes } from '@/services/api'
@@ -785,6 +785,38 @@ function SectionBlock({
     if (selectedSubBlockId === id) setSelectedSubBlockId(null)
   }, [subBlocks, updateSubBlocks, selectedSubBlockId, block.id, penCanvasRefs])
 
+  /** Intercept a newly drawn stroke: if it falls within a sub-block, route it there instead of the main canvas. */
+  const handleStrokeDrawn = useCallback((stroke: PenStroke): boolean => {
+    if (subBlocks.length === 0) return false
+    // Compute stroke centroid
+    let cx = 0, cy = 0
+    for (const p of stroke.points) { cx += p.x; cy += p.y }
+    cx /= stroke.points.length
+    cy /= stroke.points.length
+    // Find the sub-block whose bounds contain the centroid
+    const target = subBlocks.find(sb =>
+      cx >= sb.x && cx <= sb.x + sb.width &&
+      cy >= sb.y && cy <= sb.y + sb.height
+    )
+    if (!target) return false
+    // Add stroke to the sub-block's strokes variation and recalculate bounds
+    const updated = subBlocks.map(s => {
+      if (s.id !== target.id) return s
+      const currentStrokes = s.variations[0]?.strokes ?? []
+      const newStrokes = [...currentStrokes, { ...stroke, points: stroke.points.map(p => ({ ...p })) }]
+      const bounds = computeStrokeBounds(newStrokes)
+      return {
+        ...s,
+        ...bounds,
+        variations: s.variations.map((v, i) =>
+          i === 0 ? { ...v, strokes: newStrokes } : v
+        ),
+      }
+    })
+    updateSubBlocks(updated)
+    return true // consumed — don't add to main canvas
+  }, [subBlocks, updateSubBlocks])
+
   const handleSubBlockInterpret = useCallback(async (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => {
     const sb = subBlocks.find(s => s.id === id)
     if (!sb) return
@@ -1067,6 +1099,7 @@ function SectionBlock({
               onStrokeComplete={onStrokeComplete}
               onCreateSubBlock={handleCreateSubBlock}
               onTransformChange={handleCanvasTransformChange}
+              onStrokeDrawn={handleStrokeDrawn}
             />
             {/* Sub-block overlays */}
             {subBlocks.length > 0 && (
@@ -1090,6 +1123,7 @@ function SectionBlock({
                     onEdit={handleSubBlockEdit}
                     onInterpret={handleSubBlockInterpret}
                     onVariationSwitch={handleSubBlockVariationSwitch}
+                    activeTool={drawingTool.tool}
                   />
                 ))}
               </div>

--- a/client/src/components/PenCanvas.tsx
+++ b/client/src/components/PenCanvas.tsx
@@ -62,6 +62,8 @@ interface PenCanvasProps {
   onCreateSubBlock?: (data: CreateSubBlockData) => void
   /** Called when canvas transform (zoom/pan) changes */
   onTransformChange?: (scale: number, panX: number, panY: number) => void
+  /** Called when a single new stroke has been drawn (before onStrokeComplete). Return true to consume the stroke (remove it from the canvas). */
+  onStrokeDrawn?: (stroke: PenStroke) => boolean
 }
 
 /** An undoable action on the canvas */
@@ -154,6 +156,7 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
     onStrokeComplete,
     onCreateSubBlock,
     onTransformChange,
+    onStrokeDrawn,
   }, ref) {
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const wrapperRef = useRef<HTMLDivElement>(null)
@@ -938,15 +941,20 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       if (!drawingRef.current) return
       drawingRef.current = false
       if (currentStrokeRef.current && currentStrokeRef.current.points.length > 1) {
-        strokesRef.current.push(currentStrokeRef.current)
-        undoStackRef.current.push({ type: 'draw' })
-        invalidateBuffer()
-        notifyUndoState()
-        notifyStrokeComplete()
+        const stroke = currentStrokeRef.current
+        // Let parent intercept the stroke (e.g. to route it to a sub-block)
+        const consumed = onStrokeDrawn?.(stroke)
+        if (!consumed) {
+          strokesRef.current.push(stroke)
+          undoStackRef.current.push({ type: 'draw' })
+          invalidateBuffer()
+          notifyUndoState()
+          notifyStrokeComplete()
+        }
       }
       currentStrokeRef.current = null
       redraw()
-    }, [notifyUndoState, notifyStrokeComplete, invalidateBuffer, redraw, tool, finalizeLasso, cancelFirmPress])
+    }, [notifyUndoState, notifyStrokeComplete, invalidateBuffer, redraw, tool, finalizeLasso, cancelFirmPress, onStrokeDrawn])
 
     // Attach pointer events natively (React synthetic events coalesce pointer moves)
     useEffect(() => {

--- a/client/src/components/PenCanvas.tsx
+++ b/client/src/components/PenCanvas.tsx
@@ -27,6 +27,14 @@ export interface PenCanvasHandle {
   canPaste: () => boolean
   /** Whether there are selected strokes */
   hasSelection: () => boolean
+  /** Extract selected strokes into a sub-block */
+  extractSelection: () => void
+}
+
+/** Data emitted when creating a sub-block from a lasso selection */
+export interface CreateSubBlockData {
+  strokes: PenStroke[]
+  bounds: { minX: number; minY: number; maxX: number; maxY: number }
 }
 
 interface PenCanvasProps {
@@ -48,6 +56,10 @@ interface PenCanvasProps {
   onUndoStateChange?: (canUndo: boolean) => void
   /** Called after any stroke change (draw, erase, undo, move, clear) with current strokes */
   onStrokeComplete?: (strokes: PenStroke[]) => void
+  /** Called when user creates a sub-block from lasso-selected strokes */
+  onCreateSubBlock?: (data: CreateSubBlockData) => void
+  /** Called when canvas transform (zoom/pan) changes */
+  onTransformChange?: (scale: number, panX: number, panY: number) => void
 }
 
 /** An undoable action on the canvas */
@@ -56,6 +68,7 @@ type UndoAction =
   | { type: 'erase'; strokes: { stroke: PenStroke; index: number }[] }
   | { type: 'move'; indices: number[]; dx: number; dy: number }
   | { type: 'paste'; count: number }
+  | { type: 'extractSubBlock'; strokes: { stroke: PenStroke; index: number }[] }
 
 /** Module-level clipboard for copy/paste across canvas instances */
 let strokeClipboard: { strokes: PenStroke[]; centerX: number; centerY: number } | null = null
@@ -137,6 +150,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
     onStrokeErased,
     onUndoStateChange,
     onStrokeComplete,
+    onCreateSubBlock,
+    onTransformChange,
   }, ref) {
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const wrapperRef = useRef<HTMLDivElement>(null)
@@ -297,7 +312,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       setZoomDisplay(Math.round(newScale * 100))
       invalidateBuffer()
       redraw()
-    }, [redraw, invalidateBuffer])
+      onTransformChange?.(scaleRef.current, panXRef.current, panYRef.current)
+    }, [redraw, invalidateBuffer, onTransformChange])
 
     /** Zoom centered on the canvas center */
     const zoomCenter = useCallback((newScale: number) => {
@@ -314,7 +330,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       setZoomDisplay(100)
       invalidateBuffer()
       redraw()
-    }, [redraw, invalidateBuffer])
+      onTransformChange?.(1.0, 0, 0)
+    }, [redraw, invalidateBuffer, onTransformChange])
 
     useEffect(() => {
       resizeCanvas()
@@ -390,6 +407,11 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         // Remove the pasted strokes from the end
         strokesRef.current.splice(strokesRef.current.length - action.count, action.count)
         clearSelection()
+      } else if (action.type === 'extractSubBlock') {
+        // Re-insert extracted strokes at their original indices
+        for (const { stroke, index } of action.strokes) {
+          strokesRef.current.splice(Math.min(index, strokesRef.current.length), 0, stroke)
+        }
       }
       invalidateBuffer()
       redraw()
@@ -554,6 +576,30 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       notifyUndoState()
       notifyStrokeComplete()
     }, [invalidateBuffer, redraw, notifyUndoState, notifyStrokeComplete])
+
+    /** Extract selected strokes into a sub-block and remove them from the canvas */
+    const extractSelection = useCallback(() => {
+      if (selectedIndicesRef.current.length === 0) return
+      const bounds = selectionBoundsRef.current
+      if (!bounds) return
+      const sorted = [...selectedIndicesRef.current].sort((a, b) => a - b)
+      const extracted: PenStroke[] = sorted.map((idx) => cloneStroke(strokesRef.current[idx]))
+      const removed: { stroke: PenStroke; index: number }[] = sorted.map((idx) => ({
+        stroke: cloneStroke(strokesRef.current[idx]),
+        index: idx,
+      }))
+      // Remove strokes from canvas (from end to preserve indices)
+      for (let i = sorted.length - 1; i >= 0; i--) {
+        strokesRef.current.splice(sorted[i], 1)
+      }
+      undoStackRef.current.push({ type: 'extractSubBlock', strokes: removed })
+      clearSelection()
+      invalidateBuffer()
+      redraw()
+      notifyUndoState()
+      notifyStrokeComplete()
+      onCreateSubBlock?.({ strokes: extracted, bounds })
+    }, [clearSelection, invalidateBuffer, redraw, notifyUndoState, notifyStrokeComplete, onCreateSubBlock])
 
     /** Draw the lasso path and selection visuals onto the main canvas */
     const drawLassoOverlay = useCallback(() => {
@@ -1009,11 +1055,14 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         } else if (e.key === 'v' && (e.ctrlKey || e.metaKey)) {
           pasteStrokes()
           e.preventDefault()
+        } else if (e.key === 'b' && (e.ctrlKey || e.metaKey) && selectedIndicesRef.current.length > 0 && onCreateSubBlock) {
+          extractSelection()
+          e.preventDefault()
         }
       }
       wrapper.addEventListener('keydown', onKeyDown)
       return () => wrapper.removeEventListener('keydown', onKeyDown)
-    }, [tool, clearSelection, invalidateBuffer, redraw, deleteSelection, copySelection, cutSelection, pasteStrokes])
+    }, [tool, clearSelection, invalidateBuffer, redraw, deleteSelection, copySelection, cutSelection, pasteStrokes, extractSelection, onCreateSubBlock])
 
     useImperativeHandle(ref, () => ({
       getStrokes() {
@@ -1045,6 +1094,7 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       hasSelection() {
         return selectedIndicesRef.current.length > 0
       },
+      extractSelection,
       toDataURL() {
         const canvas = canvasRef.current
         if (!canvas) return ''
@@ -1076,7 +1126,7 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         }
         return offscreen.toDataURL('image/png')
       },
-    }), [redraw, undo, invalidateBuffer, notifyUndoState, notifyStrokeComplete, copySelection, cutSelection, pasteStrokes, deleteSelection])
+    }), [redraw, undo, invalidateBuffer, notifyUndoState, notifyStrokeComplete, copySelection, cutSelection, pasteStrokes, deleteSelection, extractSelection])
 
     return (
       <div
@@ -1146,6 +1196,16 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
             >
               Paste
             </button>
+            {onCreateSubBlock && (
+              <button
+                className="pen-canvas-context-item"
+                disabled={selectedIndicesRef.current.length === 0}
+                onClick={() => { extractSelection(); dismissContextMenu() }}
+                type="button"
+              >
+                Create Block
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/client/src/components/PenCanvas.tsx
+++ b/client/src/components/PenCanvas.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useImperativeHandle, forwardRef, useState } from 'react'
+import { useRef, useEffect, useCallback, useImperativeHandle, forwardRef, memo, useState } from 'react'
 import type { StrokePoint, PenStroke, StrokeTool, LineStyle } from '@/types/models'
 import { drawStroke } from '@/utils/strokeRenderer'
 
@@ -54,16 +54,24 @@ interface PenCanvasProps {
   initialStrokes?: PenStroke[]
   /** Called when strokes are erased */
   onStrokeErased?: () => void
+  /** Called with logical coordinates during erasing, so parent can erase sub-block strokes */
+  onEraseAtPoint?: (x: number, y: number) => void
   /** Called when the undo stack changes (can be used to update UI) */
   onUndoStateChange?: (canUndo: boolean) => void
-  /** Called after any stroke change (draw, erase, undo, move, clear) with current strokes */
-  onStrokeComplete?: (strokes: PenStroke[]) => void
+  /** Called after any stroke change (draw, erase, undo, move, clear) */
+  onStrokeComplete?: () => void
+  /** Called when Ctrl+Z is pressed but PenCanvas has nothing to undo — lets parent handle sub-block undo */
+  onUndoFallback?: () => void
   /** Called when user creates a sub-block from lasso-selected strokes */
   onCreateSubBlock?: (data: CreateSubBlockData) => void
+  /** Called when an extractSubBlock action is undone — parent should remove the most recently created sub-block */
+  onUndoExtractSubBlock?: () => void
   /** Called when canvas transform (zoom/pan) changes */
   onTransformChange?: (scale: number, panX: number, panY: number) => void
   /** Called when a single new stroke has been drawn (before onStrokeComplete). Return true to consume the stroke (remove it from the canvas). */
   onStrokeDrawn?: (stroke: PenStroke) => boolean
+  /** Called when a lasso selection context menu should show (pos) or hide (null) */
+  onSelectionContextMenu?: (pos: { x: number; y: number } | null) => void
 }
 
 /** An undoable action on the canvas */
@@ -83,13 +91,6 @@ const ERASER_RADIUS = 12
 const MIN_SCALE = 0.25
 const MAX_SCALE = 5.0
 const ZOOM_STEP = 0.15
-
-/** Pressure threshold to trigger context menu (0–1 scale) */
-const FIRM_PRESS_THRESHOLD = 0.45
-/** How long (ms) the pen must stay above threshold before the menu opens */
-const FIRM_PRESS_DELAY = 300
-/** Max distance (px) the pointer may drift during the firm hold */
-const FIRM_PRESS_MAX_DRIFT = 8
 
 /** Point-to-line-segment distance */
 function distToSegment(
@@ -143,7 +144,7 @@ function strokesBounds(strokes: PenStroke[], indices: number[]): { minX: number;
  * Supports zoom via pinch gesture, mouse wheel, keyboard +/-, and buttons.
  * Strokes are stored in logical (unzoomed) coordinates.
  */
-export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
+export const PenCanvas = memo(forwardRef<PenCanvasHandle, PenCanvasProps>(
   function PenCanvas({
     color = '#1a1a2e',
     strokeWidth = 2,
@@ -152,13 +153,18 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
     className,
     initialStrokes,
     onStrokeErased,
+    onEraseAtPoint,
     onUndoStateChange,
     onStrokeComplete,
+    onUndoFallback,
     onCreateSubBlock,
+    onUndoExtractSubBlock,
     onTransformChange,
     onStrokeDrawn,
+    onSelectionContextMenu,
   }, ref) {
     const canvasRef = useRef<HTMLCanvasElement>(null)
+    const ctxRef = useRef<CanvasRenderingContext2D | null>(null)
     const wrapperRef = useRef<HTMLDivElement>(null)
     const strokesRef = useRef<PenStroke[]>([])
     const currentStrokeRef = useRef<PenStroke | null>(null)
@@ -196,11 +202,58 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
     const lastPinchDistRef = useRef<number | null>(null)
     const lastPinchCenterRef = useRef<{ x: number; y: number } | null>(null)
 
-    // Firm-press context menu state
-    const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
-    const firmPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-    const firmPressOriginRef = useRef<{ x: number; y: number } | null>(null)
-    const firmPressTriggeredRef = useRef(false)
+    // Track whether we've notified parent of a context menu position
+    const contextMenuVisibleRef = useRef(false)
+
+    // rAF coalescing for pointer-move redraws
+    const rafIdRef = useRef<number | null>(null)
+
+    // Deferred eraser sub-block hit-testing: accumulate points, flush in idle/timeout
+    const pendingErasePointsRef = useRef<{ x: number; y: number }[]>([])
+    const eraseFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    /** Get the canvas 2D context (created once with low-latency hints) */
+    const getCtx = useCallback(() => {
+      if (ctxRef.current) return ctxRef.current
+      const canvas = canvasRef.current
+      if (!canvas) return null
+      const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | null
+      ctxRef.current = ctx
+      return ctx
+    }, [])
+
+    // Cached DPR to avoid repeated lookups in the hot path
+    const dprRef = useRef(window.devicePixelRatio || 1)
+
+    // ── Stable prop refs (prevent callback cascade on prop changes) ──
+    const colorRef = useRef(color)
+    colorRef.current = color
+    const strokeWidthRef = useRef(strokeWidth)
+    strokeWidthRef.current = strokeWidth
+    const lineStyleRef = useRef(lineStyle)
+    lineStyleRef.current = lineStyle
+    const toolRef = useRef(tool)
+    toolRef.current = tool
+    const onStrokeErasedRef = useRef(onStrokeErased)
+    onStrokeErasedRef.current = onStrokeErased
+    const onEraseAtPointRef = useRef(onEraseAtPoint)
+    onEraseAtPointRef.current = onEraseAtPoint
+    const onUndoStateChangeRef = useRef(onUndoStateChange)
+    onUndoStateChangeRef.current = onUndoStateChange
+    const onStrokeCompleteRef = useRef(onStrokeComplete)
+    onStrokeCompleteRef.current = onStrokeComplete
+    const onUndoFallbackRef = useRef(onUndoFallback)
+    onUndoFallbackRef.current = onUndoFallback
+    const onCreateSubBlockRef = useRef(onCreateSubBlock)
+    onCreateSubBlockRef.current = onCreateSubBlock
+    const onUndoExtractSubBlockRef = useRef(onUndoExtractSubBlock)
+    onUndoExtractSubBlockRef.current = onUndoExtractSubBlock
+    const onTransformChangeRef = useRef(onTransformChange)
+    onTransformChangeRef.current = onTransformChange
+    const onStrokeDrawnRef = useRef(onStrokeDrawn)
+    onStrokeDrawnRef.current = onStrokeDrawn
+    const onSelectionContextMenuRef = useRef(onSelectionContextMenu)
+    onSelectionContextMenuRef.current = onSelectionContextMenu
 
     /** Convert screen coords (relative to canvas element) to logical drawing coords */
     const screenToLogical = useCallback((sx: number, sy: number) => {
@@ -210,18 +263,31 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       }
     }, [])
 
-    /** Cancel any pending firm-press timer */
-    const cancelFirmPress = useCallback(() => {
-      if (firmPressTimerRef.current) {
-        clearTimeout(firmPressTimerRef.current)
-        firmPressTimerRef.current = null
-      }
-      firmPressOriginRef.current = null
-    }, [])
-
     /** Dismiss the context menu */
     const dismissContextMenu = useCallback(() => {
-      setContextMenu(null)
+      if (contextMenuVisibleRef.current) {
+        contextMenuVisibleRef.current = false
+        onSelectionContextMenuRef.current?.(null)
+      }
+    }, [])
+
+    /** Show (or reposition) the context menu at the right edge of the current selection bounds */
+    const showContextMenuForSelection = useCallback(() => {
+      const bounds = selectionBoundsRef.current
+      if (!bounds || selectedIndicesRef.current.length === 0) return
+      const menuX = bounds.maxX * scaleRef.current + panXRef.current + 8
+      const menuY = bounds.minY * scaleRef.current + panYRef.current
+      contextMenuVisibleRef.current = true
+      onSelectionContextMenuRef.current?.({ x: menuX, y: menuY })
+    }, [])
+
+    /** Schedule a redraw on the next animation frame (coalesces multiple calls per frame) */
+    const scheduleRedraw = useCallback(() => {
+      if (rafIdRef.current !== null) return
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null
+        redraw()
+      })
     }, [])
 
     /** Mark the offscreen stroke buffer as needing a re-render */
@@ -236,9 +302,12 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       const rect = canvas.getBoundingClientRect()
       cachedRectRef.current = rect
       const dpr = window.devicePixelRatio || 1
+      dprRef.current = dpr
       canvas.width = rect.width * dpr
       canvas.height = rect.height * dpr
-      const ctx = canvas.getContext('2d')
+      // Setting canvas.width resets the context state, so re-apply base transform
+      ctxRef.current = null // force re-acquire in case context was lost
+      const ctx = getCtx()
       if (ctx) {
         ctx.scale(dpr, dpr)
       }
@@ -277,7 +346,7 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
     const redraw = useCallback(() => {
       const canvas = canvasRef.current
       if (!canvas) return
-      const ctx = canvas.getContext('2d')
+      const ctx = getCtx()
       if (!ctx) return
       const dpr = window.devicePixelRatio || 1
       const w = canvas.width / dpr
@@ -317,8 +386,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       setZoomDisplay(Math.round(newScale * 100))
       invalidateBuffer()
       redraw()
-      onTransformChange?.(scaleRef.current, panXRef.current, panYRef.current)
-    }, [redraw, invalidateBuffer, onTransformChange])
+      onTransformChangeRef.current?.(scaleRef.current, panXRef.current, panYRef.current)
+    }, [redraw, invalidateBuffer])
 
     /** Zoom centered on the canvas center */
     const zoomCenter = useCallback((newScale: number) => {
@@ -335,8 +404,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       setZoomDisplay(100)
       invalidateBuffer()
       redraw()
-      onTransformChange?.(1.0, 0, 0)
-    }, [redraw, invalidateBuffer, onTransformChange])
+      onTransformChangeRef.current?.(1.0, 0, 0)
+    }, [redraw, invalidateBuffer])
 
     useEffect(() => {
       resizeCanvas()
@@ -345,9 +414,15 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       return () => observer.disconnect()
     }, [resizeCanvas])
 
-    // Load previously saved strokes for re-editing
+    // Load previously saved strokes for re-editing (only on mount or when strokes
+    // change externally — skip if canvas already has content from active drawing)
+    const initialLoadedRef = useRef(false)
     useEffect(() => {
       if (!initialStrokes || initialStrokes.length === 0) return
+      // After initial load, only accept external changes if canvas is empty
+      // (prevents resetting strokes during active drawing due to parent re-renders)
+      if (initialLoadedRef.current && strokesRef.current.length > 0) return
+      initialLoadedRef.current = true
       strokesRef.current = [...initialStrokes]
       invalidateBuffer()
       requestAnimationFrame(() => redraw())
@@ -369,12 +444,12 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
     }, [screenToLogical])
 
     const notifyUndoState = useCallback(() => {
-      onUndoStateChange?.(undoStackRef.current.length > 0)
-    }, [onUndoStateChange])
+      onUndoStateChangeRef.current?.(undoStackRef.current.length > 0)
+    }, [])
 
     const notifyStrokeComplete = useCallback(() => {
-      onStrokeComplete?.([...strokesRef.current])
-    }, [onStrokeComplete])
+      onStrokeCompleteRef.current?.()
+    }, [])
 
     /** Clear lasso selection state */
     const clearSelection = useCallback(() => {
@@ -385,6 +460,10 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       isDraggingSelectionRef.current = false
       dragStartRef.current = null
       dragTotalRef.current = { dx: 0, dy: 0 }
+      if (contextMenuVisibleRef.current) {
+        contextMenuVisibleRef.current = false
+        onSelectionContextMenuRef.current?.(null)
+      }
     }, [])
 
     /** Undo the last draw or erase action */
@@ -417,12 +496,27 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         for (const { stroke, index } of action.strokes) {
           strokesRef.current.splice(Math.min(index, strokesRef.current.length), 0, stroke)
         }
+        // Notify parent to remove the sub-block that was created from these strokes
+        onUndoExtractSubBlockRef.current?.()
       }
       invalidateBuffer()
       redraw()
       notifyUndoState()
       notifyStrokeComplete()
     }, [redraw, invalidateBuffer, notifyUndoState, notifyStrokeComplete, clearSelection])
+
+    /** Flush any accumulated eraser points to the parent for sub-block hit-testing */
+    const flushErasePoints = useCallback(() => {
+      eraseFlushTimerRef.current = null
+      const points = pendingErasePointsRef.current
+      if (points.length === 0) return
+      pendingErasePointsRef.current = []
+      const cb = onEraseAtPointRef.current
+      if (!cb) return
+      for (const p of points) {
+        cb(p.x, p.y)
+      }
+    }, [])
 
     /** Erase any stroke near the given point (point is in logical coords) */
     const eraseAtPoint = useCallback((point: StrokePoint) => {
@@ -449,10 +543,15 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       if (remaining.length !== before) {
         strokesRef.current = remaining
         invalidateBuffer()
-        redraw()
-        onStrokeErased?.()
+        scheduleRedraw()
+        onStrokeErasedRef.current?.()
       }
-    }, [redraw, invalidateBuffer, onStrokeErased])
+      // Defer sub-block erasing — accumulate points and flush after a brief pause
+      pendingErasePointsRef.current.push({ x: point.x, y: point.y })
+      if (eraseFlushTimerRef.current === null) {
+        eraseFlushTimerRef.current = setTimeout(flushErasePoints, 0)
+      }
+    }, [scheduleRedraw, invalidateBuffer, flushErasePoints])
 
     /** Finalize the lasso: determine which strokes are selected */
     const finalizeLasso = useCallback(() => {
@@ -485,7 +584,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       selectionBoundsRef.current = strokesBounds(strokesRef.current, selected)
       invalidateBuffer()
       redraw()
-    }, [clearSelection, invalidateBuffer, redraw])
+      showContextMenuForSelection()
+    }, [clearSelection, invalidateBuffer, redraw, showContextMenuForSelection])
 
     /** Check if a logical point is inside the current selection bounding box */
     const isInsideSelection = useCallback((lx: number, ly: number): boolean => {
@@ -580,7 +680,8 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       redraw()
       notifyUndoState()
       notifyStrokeComplete()
-    }, [invalidateBuffer, redraw, notifyUndoState, notifyStrokeComplete])
+      showContextMenuForSelection()
+    }, [invalidateBuffer, redraw, notifyUndoState, notifyStrokeComplete, showContextMenuForSelection])
 
     /** Extract selected strokes into a sub-block and remove them from the canvas */
     const extractSelection = useCallback(() => {
@@ -603,14 +704,14 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       redraw()
       notifyUndoState()
       notifyStrokeComplete()
-      onCreateSubBlock?.({ strokes: extracted, bounds })
-    }, [clearSelection, invalidateBuffer, redraw, notifyUndoState, notifyStrokeComplete, onCreateSubBlock])
+      onCreateSubBlockRef.current?.({ strokes: extracted, bounds })
+    }, [clearSelection, invalidateBuffer, redraw, notifyUndoState, notifyStrokeComplete])
 
     /** Draw the lasso path and selection visuals onto the main canvas */
     const drawLassoOverlay = useCallback(() => {
       const canvas = canvasRef.current
       if (!canvas) return
-      const ctx = canvas.getContext('2d')
+      const ctx = getCtx()
       if (!ctx) return
 
       ctx.save()
@@ -680,65 +781,82 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
 
         if (pointerCount > 2) return
 
-        // Dismiss context menu on any tap
-        if (contextMenu) {
-          setContextMenu(null)
-          return
-        }
-
-        // Start firm-press detection for stylus (pointerType === 'pen')
-        firmPressTriggeredRef.current = false
-        if (e.pointerType === 'pen' && e.pressure >= FIRM_PRESS_THRESHOLD) {
-          firmPressOriginRef.current = { x: sx, y: sy }
-          firmPressTimerRef.current = setTimeout(() => {
-            if (!firmPressTriggeredRef.current) {
-              firmPressTriggeredRef.current = true
-              // Cancel any in-progress drawing/lasso/erase
-              drawingRef.current = false
-              currentStrokeRef.current = null
-              lassoDrawingRef.current = false
-              erasingRef.current = false
-              setContextMenu({ x: sx, y: sy })
-              redraw()
-            }
-          }, FIRM_PRESS_DELAY)
-        }
-
         // Single pointer — draw, erase, or lasso
         const point = getPoint(e)
-        if (tool === 'lasso') {
+        if (toolRef.current === 'lasso') {
           const logical = screenToLogical(sx, sy)
-          // If we have a selection and click inside it, start dragging
           if (selectedIndicesRef.current.length > 0 && isInsideSelection(logical.x, logical.y)) {
+            dismissContextMenu()
             isDraggingSelectionRef.current = true
             dragStartRef.current = { x: logical.x, y: logical.y }
             dragTotalRef.current = { dx: 0, dy: 0 }
           } else {
-            // Start a new lasso drawing (clears any previous selection)
             clearSelection()
             lassoDrawingRef.current = true
             lassoPointsRef.current = [{ x: logical.x, y: logical.y }]
             invalidateBuffer()
             redraw()
           }
-        } else if (tool === 'eraser') {
+        } else if (toolRef.current === 'eraser') {
           erasingRef.current = true
           eraseAtPoint(point)
         } else {
           drawingRef.current = true
           currentStrokeRef.current = {
             points: [point],
-            color,
-            width: strokeWidth,
-            lineStyle: lineStyle === 'solid' ? undefined : lineStyle,
+            color: colorRef.current,
+            width: strokeWidthRef.current,
+            lineStyle: lineStyleRef.current === 'solid' ? undefined : lineStyleRef.current,
           }
         }
       },
-      [color, strokeWidth, lineStyle, tool, getPoint, eraseAtPoint, redraw, screenToLogical, isInsideSelection, clearSelection, invalidateBuffer, contextMenu],
+      [getPoint, eraseAtPoint, redraw, screenToLogical, isInsideSelection, clearSelection, invalidateBuffer, dismissContextMenu],
     )
 
     const handlePointerMove = useCallback(
       (e: PointerEvent) => {
+        // Fast exit for the common case: single-pointer drawing
+        if (drawingRef.current && currentStrokeRef.current) {
+          const coalescedEvents = e.getCoalescedEvents?.() ?? [e]
+          for (const ce of coalescedEvents) {
+            const point = getPoint(ce)
+            currentStrokeRef.current.points.push(point)
+          }
+          const currentLineStyle = currentStrokeRef.current.lineStyle ?? 'solid'
+          if (currentLineStyle !== 'solid') {
+            scheduleRedraw()
+          } else {
+            const ctx = getCtx()
+            if (ctx) {
+              const pts = currentStrokeRef.current.points
+              const segCount = coalescedEvents.length
+              if (pts.length >= 2) {
+                const dpr = dprRef.current
+                const s = scaleRef.current
+                const ds = dpr * s
+                const dx = dpr * panXRef.current
+                const dy = dpr * panYRef.current
+                ctx.setTransform(ds, 0, 0, ds, dx, dy)
+                ctx.lineCap = 'round'
+                ctx.lineJoin = 'round'
+                ctx.strokeStyle = currentStrokeRef.current.color
+                const baseWidth = currentStrokeRef.current.width
+                const startIdx = Math.max(1, pts.length - segCount)
+                const p0 = Math.max(pts[startIdx].pressure, 0.1)
+                ctx.lineWidth = baseWidth * (0.3 + p0 * 1.2)
+                ctx.beginPath()
+                ctx.moveTo(pts[startIdx - 1].x, pts[startIdx - 1].y)
+                for (let i = startIdx; i < pts.length; i++) {
+                  ctx.lineTo(pts[i].x, pts[i].y)
+                }
+                ctx.stroke()
+                ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+              }
+            }
+          }
+          return
+        }
+
         const canvas = canvasRef.current
         if (!canvas) return
         const rect = cachedRectRef.current ?? canvas.getBoundingClientRect()
@@ -748,35 +866,6 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         if (activePointersRef.current.has(e.pointerId)) {
           activePointersRef.current.set(e.pointerId, { x: sx, y: sy })
         }
-
-        // Firm-press monitoring: cancel if pointer drifts too far or pressure drops
-        if (firmPressTimerRef.current && e.pointerType === 'pen') {
-          const origin = firmPressOriginRef.current
-          if (origin) {
-            const drift = Math.hypot(sx - origin.x, sy - origin.y)
-            if (drift > FIRM_PRESS_MAX_DRIFT || e.pressure < FIRM_PRESS_THRESHOLD) {
-              cancelFirmPress()
-            }
-          }
-        }
-        // Start firm-press timer if pressure just ramped up (wasn't high at pointerdown)
-        if (!firmPressTimerRef.current && !firmPressTriggeredRef.current && e.pointerType === 'pen' && e.pressure >= FIRM_PRESS_THRESHOLD) {
-          firmPressOriginRef.current = { x: sx, y: sy }
-          firmPressTimerRef.current = setTimeout(() => {
-            if (!firmPressTriggeredRef.current) {
-              firmPressTriggeredRef.current = true
-              drawingRef.current = false
-              currentStrokeRef.current = null
-              lassoDrawingRef.current = false
-              erasingRef.current = false
-              setContextMenu({ x: sx, y: sy })
-              redraw()
-            }
-          }, FIRM_PRESS_DELAY)
-        }
-
-        // If context menu was triggered, swallow further move events
-        if (firmPressTriggeredRef.current) return
 
         // Handle pinch zoom
         if (isPinchingRef.current && activePointersRef.current.size === 2) {
@@ -798,11 +887,11 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         }
 
         // Handle lasso tool
-        if (tool === 'lasso') {
+        if (toolRef.current === 'lasso') {
           const logical = screenToLogical(sx, sy)
           if (lassoDrawingRef.current) {
             lassoPointsRef.current.push({ x: logical.x, y: logical.y })
-            redraw()
+            scheduleRedraw()
           } else if (isDraggingSelectionRef.current && dragStartRef.current) {
             const dx = logical.x - dragStartRef.current.x
             const dy = logical.y - dragStartRef.current.y
@@ -824,72 +913,23 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
               selectionBoundsRef.current.maxY += ddy
             }
             invalidateBuffer()
-            redraw()
+            scheduleRedraw()
           }
           return
         }
 
-        if (tool === 'eraser' && erasingRef.current) {
+        if (toolRef.current === 'eraser' && erasingRef.current) {
           eraseAtPoint(getPoint(e))
           return
         }
 
-        if (!drawingRef.current || !currentStrokeRef.current) return
-
-        // Use coalesced events for high-resolution pen input (recovers points
-        // the browser batches together between frames)
-        const coalescedEvents = e.getCoalescedEvents?.() ?? [e]
-        for (const ce of coalescedEvents) {
-          const point = getPoint(ce)
-          currentStrokeRef.current.points.push(point)
-        }
-
-        const currentLineStyle = currentStrokeRef.current.lineStyle ?? 'solid'
-        if (currentLineStyle !== 'solid') {
-          // Full redraw needed for correct dash pattern — but buffer is still valid
-          redraw()
-        } else {
-          // Draw incremental segments for responsiveness (in transformed coords)
-          const ctx = canvasRef.current?.getContext('2d')
-          if (ctx) {
-            const pts = currentStrokeRef.current.points
-            const segCount = coalescedEvents.length
-            if (pts.length >= 2) {
-              ctx.save()
-              ctx.translate(panXRef.current, panYRef.current)
-              ctx.scale(scaleRef.current, scaleRef.current)
-              ctx.lineCap = 'round'
-              ctx.lineJoin = 'round'
-              ctx.strokeStyle = currentStrokeRef.current.color
-              // Draw all new segments from coalesced events in one batch
-              const startIdx = Math.max(1, pts.length - segCount)
-              for (let i = startIdx; i < pts.length; i++) {
-                const prev = pts[i - 1]
-                const curr = pts[i]
-                const p = Math.max(curr.pressure, 0.1)
-                ctx.lineWidth = currentStrokeRef.current.width * (0.3 + p * 1.2)
-                ctx.beginPath()
-                ctx.moveTo(prev.x, prev.y)
-                ctx.lineTo(curr.x, curr.y)
-                ctx.stroke()
-              }
-              ctx.restore()
-            }
-          }
-        }
+        // Drawing case already handled by the fast exit above
       },
-      [getPoint, tool, eraseAtPoint, redraw, zoomAt, screenToLogical, invalidateBuffer, cancelFirmPress],
+      [getPoint, eraseAtPoint, scheduleRedraw, zoomAt, screenToLogical, invalidateBuffer],
     )
 
     const handlePointerUp = useCallback((e: PointerEvent) => {
-      cancelFirmPress()
       activePointersRef.current.delete(e.pointerId)
-
-      // If firm-press triggered context menu, swallow the pointer up
-      if (firmPressTriggeredRef.current) {
-        firmPressTriggeredRef.current = false
-        return
-      }
 
       if (activePointersRef.current.size < 2) {
         isPinchingRef.current = false
@@ -898,11 +938,10 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       }
 
       // Handle lasso tool pointer up
-      if (tool === 'lasso') {
+      if (toolRef.current === 'lasso') {
         if (lassoDrawingRef.current) {
           finalizeLasso()
         } else if (isDraggingSelectionRef.current) {
-          // Commit the move as an undoable action
           const { dx, dy } = dragTotalRef.current
           if (dx !== 0 || dy !== 0) {
             undoStackRef.current.push({
@@ -917,18 +956,24 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
           isDraggingSelectionRef.current = false
           dragStartRef.current = null
           dragTotalRef.current = { dx: 0, dy: 0 }
-          // Recompute bounds after move
           if (selectedIndicesRef.current.length > 0) {
             selectionBoundsRef.current = strokesBounds(strokesRef.current, selectedIndicesRef.current)
           }
           invalidateBuffer()
           redraw()
+          showContextMenuForSelection()
         }
         return
       }
 
       if (erasingRef.current) {
         erasingRef.current = false
+        // Flush any pending sub-block erase points
+        if (eraseFlushTimerRef.current !== null) {
+          clearTimeout(eraseFlushTimerRef.current)
+          eraseFlushTimerRef.current = null
+        }
+        flushErasePoints()
         // Batch all strokes erased during this drag into one undo action
         if (pendingErasedRef.current.length > 0) {
           undoStackRef.current.push({ type: 'erase', strokes: pendingErasedRef.current })
@@ -942,8 +987,7 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       drawingRef.current = false
       if (currentStrokeRef.current && currentStrokeRef.current.points.length > 1) {
         const stroke = currentStrokeRef.current
-        // Let parent intercept the stroke (e.g. to route it to a sub-block)
-        const consumed = onStrokeDrawn?.(stroke)
+        const consumed = onStrokeDrawnRef.current?.(stroke)
         if (!consumed) {
           strokesRef.current.push(stroke)
           undoStackRef.current.push({ type: 'draw' })
@@ -954,7 +998,7 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       }
       currentStrokeRef.current = null
       redraw()
-    }, [notifyUndoState, notifyStrokeComplete, invalidateBuffer, redraw, tool, finalizeLasso, cancelFirmPress, onStrokeDrawn])
+    }, [notifyUndoState, notifyStrokeComplete, invalidateBuffer, redraw, finalizeLasso, showContextMenuForSelection])
 
     // Attach pointer events natively (React synthetic events coalesce pointer moves)
     useEffect(() => {
@@ -996,7 +1040,11 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       if (!wrapper) return
       const onKeyDown = (e: KeyboardEvent) => {
         if (e.key === 'z' && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
-          undo()
+          if (undoStackRef.current.length > 0) {
+            undo()
+          } else {
+            onUndoFallbackRef.current?.()
+          }
           e.preventDefault()
         } else if (e.key === '+' || e.key === '=') {
           zoomCenter(scaleRef.current + ZOOM_STEP)
@@ -1022,25 +1070,13 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
       }
     }, [tool, clearSelection, invalidateBuffer, redraw])
 
-    // Dismiss context menu on Escape, and clean up timer on unmount
+    // Clean up pending rAF and timers on unmount
     useEffect(() => {
       return () => {
-        if (firmPressTimerRef.current) clearTimeout(firmPressTimerRef.current)
+        if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current)
+        if (eraseFlushTimerRef.current !== null) clearTimeout(eraseFlushTimerRef.current)
       }
     }, [])
-
-    useEffect(() => {
-      if (!contextMenu) return
-      const dismiss = () => setContextMenu(null)
-      // Dismiss on any click/tap outside the menu (captured on next tick)
-      const timer = setTimeout(() => {
-        window.addEventListener('pointerdown', dismiss, { once: true })
-      }, 0)
-      return () => {
-        clearTimeout(timer)
-        window.removeEventListener('pointerdown', dismiss)
-      }
-    }, [contextMenu])
 
     // Lasso keyboard shortcuts: Escape, Delete, Copy, Cut, Paste
     useEffect(() => {
@@ -1065,14 +1101,14 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         } else if (e.key === 'v' && (e.ctrlKey || e.metaKey)) {
           pasteStrokes()
           e.preventDefault()
-        } else if (e.key === 'b' && (e.ctrlKey || e.metaKey) && selectedIndicesRef.current.length > 0 && onCreateSubBlock) {
+        } else if (e.key === 'b' && (e.ctrlKey || e.metaKey) && selectedIndicesRef.current.length > 0 && onCreateSubBlockRef.current) {
           extractSelection()
           e.preventDefault()
         }
       }
       wrapper.addEventListener('keydown', onKeyDown)
       return () => wrapper.removeEventListener('keydown', onKeyDown)
-    }, [tool, clearSelection, invalidateBuffer, redraw, deleteSelection, copySelection, cutSelection, pasteStrokes, extractSelection, onCreateSubBlock])
+    }, [tool, clearSelection, invalidateBuffer, redraw, deleteSelection, copySelection, cutSelection, pasteStrokes, extractSelection])
 
     useImperativeHandle(ref, () => ({
       getStrokes() {
@@ -1184,49 +1220,18 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
             Reset
           </button>
         </div>
-        {contextMenu && (
-          <div
-            className="pen-canvas-context-menu"
-            style={{ left: contextMenu.x, top: contextMenu.y }}
-            onPointerDown={(e) => e.stopPropagation()}
-          >
-            <button
-              className="pen-canvas-context-item"
-              disabled={selectedIndicesRef.current.length === 0}
-              onClick={() => { copySelection(); dismissContextMenu() }}
-              type="button"
-            >
-              Copy
-            </button>
-            <button
-              className="pen-canvas-context-item"
-              disabled={selectedIndicesRef.current.length === 0}
-              onClick={() => { cutSelection(); dismissContextMenu() }}
-              type="button"
-            >
-              Cut
-            </button>
-            <button
-              className="pen-canvas-context-item"
-              disabled={!strokeClipboard || strokeClipboard.strokes.length === 0}
-              onClick={() => { pasteStrokes(); dismissContextMenu() }}
-              type="button"
-            >
-              Paste
-            </button>
-            {onCreateSubBlock && (
-              <button
-                className="pen-canvas-context-item"
-                disabled={selectedIndicesRef.current.length === 0}
-                onClick={() => { extractSelection(); dismissContextMenu() }}
-                type="button"
-              >
-                Create Block
-              </button>
-            )}
-          </div>
-        )}
       </div>
     )
   },
-)
+), (prev, next) => {
+  // Only re-render for props that affect the visual output or behavior.
+  // Callback props are stored in refs, so changes to them don't need re-renders.
+  return (
+    prev.color === next.color &&
+    prev.strokeWidth === next.strokeWidth &&
+    prev.lineStyle === next.lineStyle &&
+    prev.tool === next.tool &&
+    prev.className === next.className &&
+    prev.initialStrokes === next.initialStrokes
+  )
+})

--- a/client/src/components/PenCanvas.tsx
+++ b/client/src/components/PenCanvas.tsx
@@ -29,6 +29,8 @@ export interface PenCanvasHandle {
   hasSelection: () => boolean
   /** Extract selected strokes into a sub-block */
   extractSelection: () => void
+  /** Add strokes to the canvas (e.g. when editing a sub-block's strokes) */
+  addStrokes: (strokes: PenStroke[]) => void
 }
 
 /** Data emitted when creating a sub-block from a lasso selection */
@@ -1095,6 +1097,14 @@ export const PenCanvas = forwardRef<PenCanvasHandle, PenCanvasProps>(
         return selectedIndicesRef.current.length > 0
       },
       extractSelection,
+      addStrokes(strokes: PenStroke[]) {
+        const cloned = strokes.map(s => cloneStroke(s))
+        strokesRef.current.push(...cloned)
+        invalidateBuffer()
+        redraw()
+        notifyUndoState()
+        notifyStrokeComplete()
+      },
       toDataURL() {
         const canvas = canvasRef.current
         if (!canvas) return ''

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -32,23 +32,10 @@ function DirectStrokeCanvas({ strokes, subBlock, scale }: {
     if (!ctx) return
     ctx.clearRect(0, 0, canvas.width, canvas.height)
 
-    // Compute actual stroke bounds (matching computeStrokeBounds padding=10)
-    let minX = Infinity, minY = Infinity
-    for (const stroke of strokes) {
-      for (const p of stroke.points) {
-        if (p.x < minX) minX = p.x
-        if (p.y < minY) minY = p.y
-      }
-    }
-    const strokeOriginX = minX - 10
-    const strokeOriginY = minY - 10
-
     ctx.save()
     ctx.scale(dpr, dpr)
-    // Scale to screen coords, then offset by stroke origin so strokes
-    // render relative to the overlay box (not absolute canvas position)
+    // Points are stored relative to sub-block origin, so just scale
     ctx.scale(scale, scale)
-    ctx.translate(-strokeOriginX, -strokeOriginY)
     for (const stroke of strokes) {
       drawStroke(ctx, stroke)
     }

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -1,8 +1,55 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import type { SubBlock, SubBlockVariation, StrokeTool } from '@/types/models'
+import type { SubBlock, SubBlockVariation, StrokeTool, PenStroke } from '@/types/models'
 import { StrokePreview } from '@/components/StrokePreview'
 import { MarkdownPreview } from '@/components/MarkdownPreview'
+import { drawStroke } from '@/utils/strokeRenderer'
 import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
+
+/**
+ * Renders strokes on a canvas using the same coordinate system as PenCanvas.
+ * Instead of normalizing strokes into the container (like StrokePreview),
+ * this offsets by the sub-block's logical position so strokes appear
+ * exactly where the user drew them.
+ */
+function DirectStrokeCanvas({ strokes, subBlock, scale }: {
+  strokes: PenStroke[]
+  subBlock: SubBlock
+  scale: number
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = window.devicePixelRatio || 1
+    const w = subBlock.width * scale
+    const h = subBlock.height * scale
+    canvas.width = w * dpr
+    canvas.height = h * dpr
+    canvas.style.width = `${w}px`
+    canvas.style.height = `${h}px`
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.save()
+    ctx.scale(dpr, dpr)
+    // Transform: scale to screen coords, then offset by sub-block origin
+    ctx.scale(scale, scale)
+    ctx.translate(-subBlock.x, -subBlock.y)
+    for (const stroke of strokes) {
+      drawStroke(ctx, stroke)
+    }
+    ctx.restore()
+  }, [strokes, subBlock.x, subBlock.y, subBlock.width, subBlock.height, scale])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ display: 'block', width: '100%', height: '100%' }}
+    />
+  )
+}
 
 interface SubBlockOverlayProps {
   subBlock: SubBlock
@@ -129,7 +176,7 @@ export function SubBlockOverlay({
     switch (variation.type) {
       case 'strokes':
         return variation.strokes && variation.strokes.length > 0 ? (
-          <StrokePreview strokes={variation.strokes} className="subblock-stroke-preview" />
+          <DirectStrokeCanvas strokes={variation.strokes} subBlock={subBlock} scale={scale} />
         ) : (
           <div className="subblock-empty">Empty block</div>
         )

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import type { SubBlock, SubBlockVariation } from '@/types/models'
+import type { SubBlock, SubBlockVariation, StrokeTool } from '@/types/models'
 import { StrokePreview } from '@/components/StrokePreview'
 import { MarkdownPreview } from '@/components/MarkdownPreview'
 import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
@@ -21,6 +21,8 @@ interface SubBlockOverlayProps {
   onEdit: (id: string) => void
   onInterpret: (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => void
   onVariationSwitch: (id: string, index: number) => void
+  /** Current drawing tool — when 'pen', overlay allows drawing through */
+  activeTool?: StrokeTool
 }
 
 /** Module-level clipboard for sub-block copy/paste */
@@ -42,6 +44,7 @@ export function SubBlockOverlay({
   onEdit,
   onInterpret,
   onVariationSwitch,
+  activeTool,
 }: SubBlockOverlayProps) {
   const [interpreting, setInterpreting] = useState(false)
   const [transitioning, setTransitioning] = useState(false)
@@ -191,6 +194,9 @@ export function SubBlockOverlay({
     transitionPhase === 'exit' ? 'subblock-page-exit' :
     transitionPhase === 'enter' ? 'subblock-page-enter' : ''
 
+  // When pen tool is active, let strokes pass through to the canvas underneath
+  const penPassthrough = activeTool === 'pen'
+
   return (
     <div
       className={`subblock-overlay ${isSelected ? 'subblock-selected' : ''}`}
@@ -200,13 +206,14 @@ export function SubBlockOverlay({
         top: screenY,
         width: screenW,
         minHeight: screenH,
-        pointerEvents: 'auto',
+        pointerEvents: penPassthrough ? 'none' : 'auto',
       }}
       onClick={(e) => { e.stopPropagation(); onSelect() }}
     >
       {/* Drag handle */}
       <div
         className="subblock-drag-handle"
+        style={{ pointerEvents: 'auto' }}
         onPointerDown={handleDragStart}
         onPointerMove={handleDragMove}
         onPointerUp={handleDragEnd}
@@ -241,7 +248,7 @@ export function SubBlockOverlay({
 
       {/* Action toolbar — shown when selected */}
       {isSelected && isCanvasActive && (
-        <div className="subblock-toolbar" onClick={(e) => e.stopPropagation()}>
+        <div className="subblock-toolbar" style={{ pointerEvents: 'auto' }} onClick={(e) => e.stopPropagation()}>
           <button
             className="subblock-tool-btn"
             onClick={() => handleInterpret('readText')}

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -116,9 +116,13 @@ export function SubBlockOverlay({
     }
   }, [subBlock.activeVariationIndex, transitioning])
 
-  // Screen position from logical coordinates
-  const screenX = subBlock.x * scale + panX
-  const screenY = subBlock.y * scale + panY
+  // Chrome offsets: border (2px) + drag handle (18px) + content padding (4px)
+  const chromeTop = 2 + 18 + 4
+  const chromeLeft = 2 + 4
+
+  // Screen position from logical coordinates, offset to align content area
+  const screenX = subBlock.x * scale + panX - chromeLeft
+  const screenY = subBlock.y * scale + panY - chromeTop
   const screenW = subBlock.width * scale
   const screenH = subBlock.height * scale
 

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -77,7 +77,6 @@ interface SubBlockOverlayProps {
   onSelect: () => void
   onDragMove: (id: string, x: number, y: number) => void
   onDelete: (id: string) => void
-  onEdit: (id: string) => void
   onInterpret: (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => void
   onVariationSwitch: (id: string, index: number) => void
   /** Current drawing tool — when 'pen', overlay allows drawing through */
@@ -100,7 +99,6 @@ export function SubBlockOverlay({
   onSelect,
   onDragMove,
   onDelete,
-  onEdit,
   onInterpret,
   onVariationSwitch,
   activeTool,
@@ -334,14 +332,6 @@ export function SubBlockOverlay({
             type="button"
           >
             {interpreting ? '...' : 'Notes'}
-          </button>
-          <button
-            className="subblock-tool-btn subblock-tool-edit"
-            onClick={() => onEdit(subBlock.id)}
-            title="Edit pen strokes"
-            type="button"
-          >
-            Edit
           </button>
           <button
             className="subblock-tool-btn subblock-tool-delete"

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -18,6 +18,7 @@ interface SubBlockOverlayProps {
   onSelect: () => void
   onDragMove: (id: string, x: number, y: number) => void
   onDelete: (id: string) => void
+  onEdit: (id: string) => void
   onInterpret: (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => void
   onVariationSwitch: (id: string, index: number) => void
 }
@@ -38,6 +39,7 @@ export function SubBlockOverlay({
   onSelect,
   onDragMove,
   onDelete,
+  onEdit,
   onInterpret,
   onVariationSwitch,
 }: SubBlockOverlayProps) {
@@ -266,6 +268,14 @@ export function SubBlockOverlay({
             type="button"
           >
             {interpreting ? '...' : 'Notes'}
+          </button>
+          <button
+            className="subblock-tool-btn subblock-tool-edit"
+            onClick={() => onEdit(subBlock.id)}
+            title="Edit pen strokes"
+            type="button"
+          >
+            Edit
           </button>
           <button
             className="subblock-tool-btn subblock-tool-delete"

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import type { SubBlock, SubBlockVariation, StrokeTool, PenStroke } from '@/types/models'
-import { StrokePreview } from '@/components/StrokePreview'
+
 import { MarkdownPreview } from '@/components/MarkdownPreview'
 import { drawStroke } from '@/utils/strokeRenderer'
 import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
@@ -56,15 +56,10 @@ interface SubBlockOverlayProps {
   scale: number
   panX: number
   panY: number
-  /** Whether the canvas is active (pen mode) */
-  isCanvasActive: boolean
   /** Whether this sub-block is selected */
   isSelected: boolean
-  online: boolean
   onSelect: () => void
   onDragMove: (id: string, x: number, y: number) => void
-  onDelete: (id: string) => void
-  onInterpret: (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => void
   onVariationSwitch: (id: string, index: number) => void
   /** Current drawing tool — when 'pen', overlay allows drawing through */
   activeTool?: StrokeTool
@@ -80,17 +75,12 @@ export function SubBlockOverlay({
   scale,
   panX,
   panY,
-  isCanvasActive,
   isSelected,
-  online,
   onSelect,
   onDragMove,
-  onDelete,
-  onInterpret,
   onVariationSwitch,
   activeTool,
 }: SubBlockOverlayProps) {
-  const [interpreting, setInterpreting] = useState(false)
   const [transitioning, setTransitioning] = useState(false)
   const [displayedIndex, setDisplayedIndex] = useState(subBlock.activeVariationIndex)
   const [transitionPhase, setTransitionPhase] = useState<'none' | 'exit' | 'enter'>('none')
@@ -162,16 +152,6 @@ export function SubBlockOverlay({
     }, 250)
   }, [transitioning, displayedIndex, subBlock.id, onVariationSwitch])
 
-  // ── Interpret actions ──
-  const handleInterpret = useCallback(async (mode: 'readText' | 'interpret' | 'meetingNotes') => {
-    setInterpreting(true)
-    try {
-      await onInterpret(subBlock.id, mode)
-    } finally {
-      setInterpreting(false)
-    }
-  }, [subBlock.id, onInterpret])
-
   // ── Render variation content ──
   const renderVariationContent = (variation: SubBlockVariation) => {
     switch (variation.type) {
@@ -242,8 +222,8 @@ export function SubBlockOverlay({
     transitionPhase === 'exit' ? 'subblock-page-exit' :
     transitionPhase === 'enter' ? 'subblock-page-enter' : ''
 
-  // When pen tool is active, let strokes pass through to the canvas underneath
-  const penPassthrough = activeTool === 'pen'
+  // When pen or eraser tool is active, let events pass through to the canvas underneath
+  const penPassthrough = activeTool === 'pen' || activeTool === 'eraser'
 
   return (
     <div
@@ -294,46 +274,6 @@ export function SubBlockOverlay({
         </div>
       )}
 
-      {/* Action toolbar — shown when selected */}
-      {isSelected && isCanvasActive && (
-        <div className="subblock-toolbar" style={{ pointerEvents: 'auto' }} onClick={(e) => e.stopPropagation()}>
-          <button
-            className="subblock-tool-btn"
-            onClick={() => handleInterpret('readText')}
-            disabled={interpreting || !online}
-            title="Extract text from drawing"
-            type="button"
-          >
-            {interpreting ? '...' : 'Read'}
-          </button>
-          <button
-            className="subblock-tool-btn"
-            onClick={() => handleInterpret('interpret')}
-            disabled={interpreting || !online}
-            title="Interpret drawing (mindmap, diagram, etc.)"
-            type="button"
-          >
-            {interpreting ? '...' : 'Interpret'}
-          </button>
-          <button
-            className="subblock-tool-btn"
-            onClick={() => handleInterpret('meetingNotes')}
-            disabled={interpreting || !online}
-            title="Extract meeting notes"
-            type="button"
-          >
-            {interpreting ? '...' : 'Notes'}
-          </button>
-          <button
-            className="subblock-tool-btn subblock-tool-delete"
-            onClick={() => onDelete(subBlock.id)}
-            title="Delete block (re-insert strokes)"
-            type="button"
-          >
-            &times;
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -1,0 +1,282 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import type { SubBlock, SubBlockVariation } from '@/types/models'
+import { StrokePreview } from '@/components/StrokePreview'
+import { MarkdownPreview } from '@/components/MarkdownPreview'
+import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
+
+interface SubBlockOverlayProps {
+  subBlock: SubBlock
+  /** Canvas transform for positioning */
+  scale: number
+  panX: number
+  panY: number
+  /** Whether the canvas is active (pen mode) */
+  isCanvasActive: boolean
+  /** Whether this sub-block is selected */
+  isSelected: boolean
+  online: boolean
+  onSelect: () => void
+  onDragMove: (id: string, x: number, y: number) => void
+  onDelete: (id: string) => void
+  onInterpret: (id: string, mode: 'readText' | 'interpret' | 'meetingNotes') => void
+  onVariationSwitch: (id: string, index: number) => void
+}
+
+/** Module-level clipboard for sub-block copy/paste */
+let subBlockClipboard: SubBlock | null = null
+export function getSubBlockClipboard() { return subBlockClipboard }
+export function setSubBlockClipboard(sb: SubBlock | null) { subBlockClipboard = sb }
+
+export function SubBlockOverlay({
+  subBlock,
+  scale,
+  panX,
+  panY,
+  isCanvasActive,
+  isSelected,
+  online,
+  onSelect,
+  onDragMove,
+  onDelete,
+  onInterpret,
+  onVariationSwitch,
+}: SubBlockOverlayProps) {
+  const [interpreting, setInterpreting] = useState(false)
+  const [transitioning, setTransitioning] = useState(false)
+  const [displayedIndex, setDisplayedIndex] = useState(subBlock.activeVariationIndex)
+  const [transitionPhase, setTransitionPhase] = useState<'none' | 'exit' | 'enter'>('none')
+  const dragStartRef = useRef<{ x: number; y: number; blockX: number; blockY: number } | null>(null)
+
+  // Sync displayed index when activeVariationIndex changes externally
+  useEffect(() => {
+    if (!transitioning) {
+      setDisplayedIndex(subBlock.activeVariationIndex)
+    }
+  }, [subBlock.activeVariationIndex, transitioning])
+
+  // Screen position from logical coordinates
+  const screenX = subBlock.x * scale + panX
+  const screenY = subBlock.y * scale + panY
+  const screenW = subBlock.width * scale
+  const screenH = subBlock.height * scale
+
+  const activeVariation = subBlock.variations[displayedIndex] ?? subBlock.variations[0]
+
+  // ── Dragging ──
+  const handleDragStart = useCallback((e: React.PointerEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    onSelect()
+    dragStartRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+      blockX: subBlock.x,
+      blockY: subBlock.y,
+    }
+    const el = e.currentTarget as HTMLElement
+    el.setPointerCapture(e.pointerId)
+  }, [onSelect, subBlock.x, subBlock.y])
+
+  const handleDragMove = useCallback((e: React.PointerEvent) => {
+    if (!dragStartRef.current) return
+    const dx = (e.clientX - dragStartRef.current.x) / scale
+    const dy = (e.clientY - dragStartRef.current.y) / scale
+    onDragMove(subBlock.id, dragStartRef.current.blockX + dx, dragStartRef.current.blockY + dy)
+  }, [scale, subBlock.id, onDragMove])
+
+  const handleDragEnd = useCallback((e: React.PointerEvent) => {
+    if (!dragStartRef.current) return
+    dragStartRef.current = null
+    const el = e.currentTarget as HTMLElement
+    el.releasePointerCapture(e.pointerId)
+  }, [])
+
+  // ── Variation switching with page-fold transition ──
+  const switchVariation = useCallback((targetIndex: number) => {
+    if (transitioning || targetIndex === displayedIndex) return
+    setTransitioning(true)
+    setTransitionPhase('exit')
+
+    setTimeout(() => {
+      setDisplayedIndex(targetIndex)
+      setTransitionPhase('enter')
+      onVariationSwitch(subBlock.id, targetIndex)
+
+      setTimeout(() => {
+        setTransitionPhase('none')
+        setTransitioning(false)
+      }, 250)
+    }, 250)
+  }, [transitioning, displayedIndex, subBlock.id, onVariationSwitch])
+
+  // ── Interpret actions ──
+  const handleInterpret = useCallback(async (mode: 'readText' | 'interpret' | 'meetingNotes') => {
+    setInterpreting(true)
+    try {
+      await onInterpret(subBlock.id, mode)
+    } finally {
+      setInterpreting(false)
+    }
+  }, [subBlock.id, onInterpret])
+
+  // ── Render variation content ──
+  const renderVariationContent = (variation: SubBlockVariation) => {
+    switch (variation.type) {
+      case 'strokes':
+        return variation.strokes && variation.strokes.length > 0 ? (
+          <StrokePreview strokes={variation.strokes} className="subblock-stroke-preview" />
+        ) : (
+          <div className="subblock-empty">Empty block</div>
+        )
+
+      case 'readText':
+        return variation.markdown ? (
+          <div className="subblock-text-content">
+            <MarkdownPreview content={variation.markdown} />
+          </div>
+        ) : (
+          <div className="subblock-empty">No text extracted</div>
+        )
+
+      case 'interpret': {
+        const interp = variation.interpretation as CanvasInterpretation | undefined
+        if (!interp) return <div className="subblock-empty">No interpretation</div>
+        return (
+          <div className="subblock-interpret-content">
+            <div className="subblock-interpret-category">{interp.category}</div>
+            <div className="subblock-interpret-description">{interp.description}</div>
+            {interp.items?.length > 0 && (
+              <ul className="subblock-interpret-items">
+                {interp.items.map((item) => (
+                  <li key={item.item_id}>{item.item}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
+      }
+
+      case 'meetingNotes': {
+        const notes = variation.meetingNotes as MeetingNotesResult | undefined
+        if (!notes) return <div className="subblock-empty">No meeting notes</div>
+        return (
+          <div className="subblock-meeting-content">
+            {notes.title && <strong>{notes.title}</strong>}
+            {notes.summary && <p>{notes.summary}</p>}
+            {notes.next_steps?.length > 0 && (
+              <ul>
+                {notes.next_steps.map((step, i) => (
+                  <li key={i}>{step.action}{step.owner ? ` (${step.owner})` : ''}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
+      }
+    }
+  }
+
+  const variationLabel = (v: SubBlockVariation) => {
+    switch (v.type) {
+      case 'strokes': return 'Pen'
+      case 'readText': return 'Text'
+      case 'interpret': return 'Visual'
+      case 'meetingNotes': return 'Notes'
+    }
+  }
+
+  const transitionClass =
+    transitionPhase === 'exit' ? 'subblock-page-exit' :
+    transitionPhase === 'enter' ? 'subblock-page-enter' : ''
+
+  return (
+    <div
+      className={`subblock-overlay ${isSelected ? 'subblock-selected' : ''}`}
+      style={{
+        position: 'absolute',
+        left: screenX,
+        top: screenY,
+        width: screenW,
+        minHeight: screenH,
+        pointerEvents: 'auto',
+      }}
+      onClick={(e) => { e.stopPropagation(); onSelect() }}
+    >
+      {/* Drag handle */}
+      <div
+        className="subblock-drag-handle"
+        onPointerDown={handleDragStart}
+        onPointerMove={handleDragMove}
+        onPointerUp={handleDragEnd}
+        onPointerCancel={handleDragEnd}
+      >
+        <span className="subblock-drag-dots">&#x2801;&#x2801;&#x2801;</span>
+      </div>
+
+      {/* Variation content with page-fold transition */}
+      <div className="subblock-content-wrapper" style={{ perspective: '600px' }}>
+        <div className={`subblock-content ${transitionClass}`}>
+          {renderVariationContent(activeVariation)}
+        </div>
+      </div>
+
+      {/* Variation switcher dots */}
+      {subBlock.variations.length > 1 && (
+        <div className="subblock-variation-switcher">
+          {subBlock.variations.map((v, i) => (
+            <button
+              key={v.id}
+              className={`subblock-variation-dot ${i === displayedIndex ? 'active' : ''}`}
+              onClick={(e) => { e.stopPropagation(); switchVariation(i) }}
+              title={variationLabel(v)}
+              type="button"
+            >
+              {variationLabel(v)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Action toolbar — shown when selected */}
+      {isSelected && isCanvasActive && (
+        <div className="subblock-toolbar" onClick={(e) => e.stopPropagation()}>
+          <button
+            className="subblock-tool-btn"
+            onClick={() => handleInterpret('readText')}
+            disabled={interpreting || !online}
+            title="Extract text from drawing"
+            type="button"
+          >
+            {interpreting ? '...' : 'Read'}
+          </button>
+          <button
+            className="subblock-tool-btn"
+            onClick={() => handleInterpret('interpret')}
+            disabled={interpreting || !online}
+            title="Interpret drawing (mindmap, diagram, etc.)"
+            type="button"
+          >
+            {interpreting ? '...' : 'Interpret'}
+          </button>
+          <button
+            className="subblock-tool-btn"
+            onClick={() => handleInterpret('meetingNotes')}
+            disabled={interpreting || !online}
+            title="Extract meeting notes"
+            type="button"
+          >
+            {interpreting ? '...' : 'Notes'}
+          </button>
+          <button
+            className="subblock-tool-btn subblock-tool-delete"
+            onClick={() => onDelete(subBlock.id)}
+            title="Delete block (re-insert strokes)"
+            type="button"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/SubBlockOverlay.tsx
+++ b/client/src/components/SubBlockOverlay.tsx
@@ -6,10 +6,9 @@ import { drawStroke } from '@/utils/strokeRenderer'
 import type { CanvasInterpretation, MeetingNotesResult } from '@/services/api'
 
 /**
- * Renders strokes on a canvas using the same coordinate system as PenCanvas.
- * Instead of normalizing strokes into the container (like StrokePreview),
- * this offsets by the sub-block's logical position so strokes appear
- * exactly where the user drew them.
+ * Renders strokes on a canvas relative to the sub-block's bounding box.
+ * Computes the actual stroke bounds from point data so that when the
+ * sub-block is dragged to a new position the strokes move with it.
  */
 function DirectStrokeCanvas({ strokes, subBlock, scale }: {
   strokes: PenStroke[]
@@ -32,16 +31,29 @@ function DirectStrokeCanvas({ strokes, subBlock, scale }: {
     const ctx = canvas.getContext('2d')
     if (!ctx) return
     ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+    // Compute actual stroke bounds (matching computeStrokeBounds padding=10)
+    let minX = Infinity, minY = Infinity
+    for (const stroke of strokes) {
+      for (const p of stroke.points) {
+        if (p.x < minX) minX = p.x
+        if (p.y < minY) minY = p.y
+      }
+    }
+    const strokeOriginX = minX - 10
+    const strokeOriginY = minY - 10
+
     ctx.save()
     ctx.scale(dpr, dpr)
-    // Transform: scale to screen coords, then offset by sub-block origin
+    // Scale to screen coords, then offset by stroke origin so strokes
+    // render relative to the overlay box (not absolute canvas position)
     ctx.scale(scale, scale)
-    ctx.translate(-subBlock.x, -subBlock.y)
+    ctx.translate(-strokeOriginX, -strokeOriginY)
     for (const stroke of strokes) {
       drawStroke(ctx, stroke)
     }
     ctx.restore()
-  }, [strokes, subBlock.x, subBlock.y, subBlock.width, subBlock.height, scale])
+  }, [strokes, subBlock.width, subBlock.height, scale])
 
   return (
     <canvas

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -2533,10 +2533,244 @@ kbd {
   outline-offset: 2px;
 }
 
+/* ── Sub-block overlays ────────────────────────── */
+
+.subblock-overlay {
+  border: 2px dashed var(--color-accent, #4a6cf7);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  cursor: default;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+}
+
+.subblock-overlay.subblock-selected {
+  border-color: var(--color-accent, #4a6cf7);
+  border-style: solid;
+  box-shadow: 0 2px 12px rgba(74, 108, 247, 0.25);
+}
+
+.subblock-drag-handle {
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  background: rgba(74, 108, 247, 0.08);
+  border-radius: 4px 4px 0 0;
+  touch-action: none;
+  user-select: none;
+}
+
+.subblock-drag-handle:active {
+  cursor: grabbing;
+}
+
+.subblock-drag-dots {
+  font-size: 10px;
+  color: #999;
+  letter-spacing: 2px;
+}
+
+.subblock-content-wrapper {
+  flex: 1;
+  overflow: hidden;
+  min-height: 30px;
+}
+
+.subblock-content {
+  padding: 4px;
+  transform-origin: center left;
+  backface-visibility: hidden;
+}
+
+/* Page-fold transition */
+.subblock-page-exit {
+  animation: subblock-fold-out 250ms ease-in forwards;
+}
+
+.subblock-page-enter {
+  animation: subblock-fold-in 250ms ease-out forwards;
+}
+
+@keyframes subblock-fold-out {
+  from { transform: rotateY(0deg); opacity: 1; }
+  to   { transform: rotateY(90deg); opacity: 0; }
+}
+
+@keyframes subblock-fold-in {
+  from { transform: rotateY(-90deg); opacity: 0; }
+  to   { transform: rotateY(0deg); opacity: 1; }
+}
+
+.subblock-variation-switcher {
+  display: flex;
+  gap: 4px;
+  padding: 3px 4px;
+  justify-content: center;
+  border-top: 1px solid #eee;
+}
+
+.subblock-variation-dot {
+  font-size: 9px;
+  padding: 1px 6px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #f5f5f5;
+  cursor: pointer;
+  color: #666;
+}
+
+.subblock-variation-dot.active {
+  background: var(--color-accent, #4a6cf7);
+  color: white;
+  border-color: var(--color-accent, #4a6cf7);
+}
+
+.subblock-toolbar {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border-top: 1px solid #eee;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.subblock-tool-btn {
+  font-size: 10px;
+  padding: 2px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  cursor: pointer;
+  color: #333;
+}
+
+.subblock-tool-btn:hover:not(:disabled) {
+  background: #f0f0f0;
+}
+
+.subblock-tool-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.subblock-tool-delete {
+  color: #d33;
+  border-color: #d33;
+  font-size: 14px;
+  padding: 0 6px;
+}
+
+.subblock-stroke-preview {
+  max-height: 200px;
+}
+
+.subblock-text-content {
+  padding: 4px 8px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.subblock-interpret-content {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.subblock-interpret-category {
+  font-weight: 600;
+  text-transform: capitalize;
+  color: var(--color-accent, #4a6cf7);
+  margin-bottom: 2px;
+}
+
+.subblock-interpret-description {
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.subblock-interpret-items {
+  margin: 0;
+  padding-left: 16px;
+  font-size: 11px;
+}
+
+.subblock-meeting-content {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.subblock-meeting-content strong {
+  display: block;
+  margin-bottom: 2px;
+}
+
+.subblock-meeting-content ul {
+  margin: 2px 0;
+  padding-left: 16px;
+  font-size: 11px;
+}
+
+.subblock-empty {
+  padding: 12px;
+  text-align: center;
+  color: #999;
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* Sub-block previews (shown when canvas is inactive) */
+.subblock-previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.subblock-preview-card {
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 6px;
+  background: #fafafa;
+  min-width: 80px;
+  max-width: 180px;
+  position: relative;
+}
+
+.subblock-preview-strokes {
+  max-height: 80px;
+}
+
+.subblock-preview-text {
+  font-size: 11px;
+  color: #555;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+}
+
+.subblock-preview-badge {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 9px;
+  color: var(--color-accent, #4a6cf7);
+  background: rgba(74, 108, 247, 0.1);
+  padding: 0 4px;
+  border-radius: 4px;
+}
+
 /* ── Reduced motion preference ─────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
   * {
     transition-duration: 0.01ms !important;
+  }
+  .subblock-page-exit,
+  .subblock-page-enter {
+    animation-duration: 0.01ms !important;
   }
 }

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -2657,6 +2657,11 @@ kbd {
   cursor: default;
 }
 
+.subblock-tool-edit {
+  color: #4a6cf7;
+  border-color: #4a6cf7;
+}
+
 .subblock-tool-delete {
   color: #d33;
   border-color: #d33;

--- a/client/src/styles/app.css
+++ b/client/src/styles/app.css
@@ -1185,6 +1185,9 @@ kbd {
   border-radius: var(--radius-md);
   cursor: crosshair;
   display: block;
+  touch-action: none;
+  will-change: contents;
+  contain: layout style;
 }
 
 .pen-canvas-zoom-wrapper.pen-canvas-title .pen-canvas {
@@ -1266,12 +1269,12 @@ kbd {
   background: var(--color-surface);
 }
 
-/* Context menu triggered by firm pen press */
+/* Context menu for lasso selection and sub-blocks */
 .pen-canvas-context-menu {
   position: absolute;
   z-index: 100;
-  transform: translate(-50%, -100%) translateY(-12px);
   display: flex;
+  flex-direction: column;
   gap: 2px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
@@ -1291,6 +1294,7 @@ kbd {
   border-radius: var(--radius-sm);
   cursor: pointer;
   white-space: nowrap;
+  text-align: left;
   transition: background var(--transition-fast);
 }
 
@@ -1301,6 +1305,21 @@ kbd {
 .pen-canvas-context-item:disabled {
   opacity: 0.35;
   cursor: default;
+}
+
+.pen-canvas-context-divider {
+  display: block;
+  height: 1px;
+  background: var(--color-border);
+  margin: 2px 4px;
+}
+
+.pen-canvas-context-danger {
+  color: var(--color-danger, #d32f2f);
+}
+
+.pen-canvas-context-danger:hover:not(:disabled) {
+  background: rgba(211, 47, 47, 0.08);
 }
 
 /* Quick-access tool buttons below canvas */

--- a/client/src/types/models.ts
+++ b/client/src/types/models.ts
@@ -92,6 +92,44 @@ export interface Tag {
 /** Semantic section type. Extensible — add more types here as needed. */
 export type SectionType = 'heading' | 'body'
 
+/** The kind of content a sub-block variation holds */
+export type VariationType = 'strokes' | 'readText' | 'interpret' | 'meetingNotes'
+
+/**
+ * One rendered form of a sub-block: the original pen strokes, or an
+ * AI-produced interpretation.  Only the field matching `type` is populated.
+ */
+export interface SubBlockVariation {
+  id: string
+  type: VariationType
+  /** Original pen strokes (type === 'strokes') */
+  strokes?: PenStroke[]
+  /** Extracted handwritten text as Markdown (type === 'readText') */
+  markdown?: string
+  /** Visual interpretation — items & relationships (type === 'interpret') */
+  interpretation?: unknown
+  /** Structured meeting notes (type === 'meetingNotes') */
+  meetingNotes?: unknown
+  createdAt: string
+}
+
+/**
+ * A grouped set of strokes extracted from the canvas via lasso selection.
+ * Lives inside a ContentBlock at a specific canvas position and supports
+ * multiple variations (original pen, interpreted text, visual, etc.).
+ */
+export interface SubBlock {
+  id: string
+  /** Position in logical (un-zoomed) canvas coordinates */
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Index 0 is always the original strokes variation */
+  variations: SubBlockVariation[]
+  activeVariationIndex: number
+}
+
 /**
  * A content section within a card.
  * Each section has a semantic type and can hold BOTH text and drawing content.
@@ -103,6 +141,8 @@ export interface ContentBlock {
   textContent: string
   /** Stroke data from pen input. Empty array if no drawing. */
   drawingContent: PenStroke[]
+  /** Sub-blocks extracted from this canvas section */
+  subBlocks?: SubBlock[]
 }
 
 /** Returns true if the block has any drawing content */

--- a/client/src/utils/cardBlocks.ts
+++ b/client/src/utils/cardBlocks.ts
@@ -54,12 +54,14 @@ export function computeStrokeBounds(strokes: PenStroke[], padding = 10): { x: nu
  */
 export function createSubBlockFromStrokes(strokes: PenStroke[]): SubBlock {
   const bounds = computeStrokeBounds(strokes)
+  // Store points relative to the sub-block origin so dragging
+  // only needs to update x/y without translating every point.
   const variation: SubBlockVariation = {
     id: nextVariationId(),
     type: 'strokes',
     strokes: strokes.map(s => ({
       ...s,
-      points: s.points.map(p => ({ ...p })),
+      points: s.points.map(p => ({ ...p, x: p.x - bounds.x, y: p.y - bounds.y })),
     })),
     createdAt: new Date().toISOString(),
   }

--- a/client/src/utils/cardBlocks.ts
+++ b/client/src/utils/cardBlocks.ts
@@ -5,13 +5,70 @@
  * can hold both text and drawing content simultaneously.
  */
 
-import type { ContentBlock } from '@/types/models'
+import type { ContentBlock, PenStroke, SubBlock, SubBlockVariation } from '@/types/models'
 import { hasDrawing } from '@/types/models'
 
 let blockIdCounter = 0
 
 export function nextBlockId(): string {
   return `blk_${Date.now()}_${++blockIdCounter}`
+}
+
+let subBlockIdCounter = 0
+
+export function nextSubBlockId(): string {
+  return `sb_${Date.now()}_${++subBlockIdCounter}`
+}
+
+let variationIdCounter = 0
+
+export function nextVariationId(): string {
+  return `var_${Date.now()}_${++variationIdCounter}`
+}
+
+/**
+ * Compute axis-aligned bounding box for an array of strokes.
+ * Returns position and dimensions with padding.
+ */
+export function computeStrokeBounds(strokes: PenStroke[], padding = 10): { x: number; y: number; width: number; height: number } {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const stroke of strokes) {
+    for (const p of stroke.points) {
+      if (p.x < minX) minX = p.x
+      if (p.y < minY) minY = p.y
+      if (p.x > maxX) maxX = p.x
+      if (p.y > maxY) maxY = p.y
+    }
+  }
+  return {
+    x: minX - padding,
+    y: minY - padding,
+    width: Math.max(maxX - minX + padding * 2, 40),
+    height: Math.max(maxY - minY + padding * 2, 40),
+  }
+}
+
+/**
+ * Create a SubBlock from extracted lasso strokes.
+ * The strokes become the first (index 0) variation.
+ */
+export function createSubBlockFromStrokes(strokes: PenStroke[]): SubBlock {
+  const bounds = computeStrokeBounds(strokes)
+  const variation: SubBlockVariation = {
+    id: nextVariationId(),
+    type: 'strokes',
+    strokes: strokes.map(s => ({
+      ...s,
+      points: s.points.map(p => ({ ...p })),
+    })),
+    createdAt: new Date().toISOString(),
+  }
+  return {
+    id: nextSubBlockId(),
+    ...bounds,
+    variations: [variation],
+    activeVariationIndex: 0,
+  }
 }
 
 /**

--- a/docs/pen_drawing_performance.md
+++ b/docs/pen_drawing_performance.md
@@ -1,0 +1,213 @@
+# Pen Drawing Performance: Event Path & Improvement Areas
+
+## Event Path Overview
+
+The pen drawing pipeline has 3 phases: pointer down (setup), pointer move (hot path), and pointer up (commit). All drawing state is stored in refs to avoid React re-renders during active drawing.
+
+---
+
+## Phase 1: `handlePointerDown` (PenCanvas.tsx:760)
+
+1. Reads cached bounding rect (`cachedRectRef`) — avoids `getBoundingClientRect()` per event
+2. `canvas.setPointerCapture(e.pointerId)` — locks all future events to this canvas
+3. If 2 pointers detected → enters pinch mode, returns early
+4. For pen tool:
+   - Sets `drawingRef.current = true`
+   - Creates `currentStrokeRef.current = { points: [firstPoint], color, width, lineStyle }`
+   - Color/width/lineStyle read from **refs** (not props)
+5. **No React state changes** — entirely ref-based
+
+## Phase 2: `handlePointerMove` — HOT PATH (PenCanvas.tsx:820)
+
+Takes a fast exit at the very top when `drawingRef.current && currentStrokeRef.current`:
+
+```
+1. e.getCoalescedEvents()         → get all batched stylus events (4-8 per frame on stylus)
+2. For each coalesced event:
+   getPoint(ce)                   → screenToLogical() coord transform, reads pressure/tilt/timestamp
+   currentStroke.points.push(pt)  → append to existing array
+3. For solid lines (common case):
+   getCtx()                       → cached ref lookup (created once with desynchronized: true)
+   ctx.setTransform(ds,0,0,ds,dx,dy) → apply zoom/pan (no save/restore)
+   ctx.lineCap/lineJoin/strokeStyle/lineWidth → set stroke properties
+   ctx.beginPath()                → only draw NEW segments (not full redraw)
+   ctx.moveTo(lastExistingPoint)
+   ctx.lineTo(newPoints...)
+   ctx.stroke()                   → render to canvas
+   ctx.setTransform(dpr,0,0,dpr,0,0) → reset transform
+4. return                         → skip all other handler logic (eraser, lasso, pinch)
+```
+
+**What does NOT happen in the hot path:**
+- No React state updates
+- No DOM manipulation
+- No full canvas redraw
+- No buffer invalidation
+- No localStorage save
+- No callback to parent component
+
+## Phase 3: `handlePointerUp` — Stroke Commit (PenCanvas.tsx:935)
+
+1. `drawingRef.current = false`
+2. If stroke has >1 point, calls `onStrokeDrawnRef.current(stroke)`:
+   - **CardEditor.tsx:977** `handleStrokeDrawn`: checks if stroke centroid falls inside a sub-block
+   - If inside sub-block: routes stroke there → `updateSubBlocks()` → `setSubBlocks()` → **React state update**
+   - If not consumed: pushes to `strokesRef`, `undoStackRef`, marks buffer dirty
+3. `notifyUndoState()` → `setCanUndo(true)` → **React state update** (but PenCanvas memo ignores it)
+4. `notifyStrokeComplete()` → starts 2-second debounce timer for localStorage save
+5. `currentStrokeRef.current = null`
+6. `redraw()`:
+   - Clears entire canvas
+   - `updateBuffer()` — if buffer dirty, re-renders ALL completed strokes to offscreen canvas
+   - Blits offscreen buffer to visible canvas
+   - Draws lasso overlay (if any)
+
+---
+
+## React Re-render Protection
+
+PenCanvas is wrapped in `memo(forwardRef(...))` with a custom comparator:
+```typescript
+(prev, next) => {
+  prev.color === next.color &&
+  prev.strokeWidth === next.strokeWidth &&
+  prev.lineStyle === next.lineStyle &&
+  prev.tool === next.tool &&
+  prev.className === next.className &&
+  prev.initialStrokes === next.initialStrokes
+}
+```
+
+All callback props are stored in refs (`onStrokeCompleteRef`, `onStrokeDrawnRef`, etc.) so callback identity changes don't cause re-renders or re-create handlers.
+
+| Event | Triggers React re-render? | Re-renders PenCanvas? |
+|-------|--------------------------|----------------------|
+| `handlePointerMove` (drawing) | No | No |
+| `handlePointerUp` → `notifyUndoState` | Yes (`setCanUndo`) | No — memo ignores |
+| `handlePointerUp` → consumed by sub-block | Yes (`setSubBlocks`) | No — memo ignores |
+| `handleStrokeComplete` timer fires | No (localStorage only) | No |
+| `handleCanvasTransformChange` (zoom) | Yes (`setCanvasTransform`) | No — memo ignores |
+| Context menu show/hide | Yes (`setContextMenuVersion`) | No — memo ignores |
+
+## Event Listener Stability
+
+Event listeners are attached natively (not React synthetic) via `useEffect` at line 1008:
+```typescript
+canvas.addEventListener('pointerdown', handlePointerDown)
+canvas.addEventListener('pointermove', handlePointerMove)
+canvas.addEventListener('pointerup', handlePointerUp)
+```
+
+The `useEffect` depends on `[handlePointerDown, handlePointerMove, handlePointerUp]`. If any handler identity changes, listeners are detached and re-added — potentially dropping events mid-stroke.
+
+All inner callbacks use `useCallback(fn, [])` with empty deps (reading from refs), so they should be identity-stable.
+
+---
+
+## Remaining Possible Lag Sources (Investigation Areas)
+
+### 1. `desynchronized` canvas context may not be active
+Even with `{ desynchronized: true }`, some browsers silently fall back. The drawing still goes through the browser's normal compositing pipeline (GPU sync, display refresh), adding ~16ms latency.
+
+**To verify:** Log `ctx.getContextAttributes().desynchronized` after creation. If `false`, the optimization isn't working.
+
+**Fix options:**
+- Use `OffscreenCanvas` with a worker for drawing
+- Investigate `WebGL` for direct GPU rendering
+
+### 2. SubBlockOverlay DOM compositing
+The `.subblock-overlay-container` div sits on top of the canvas with `pointer-events: none`. Even with pointer-events disabled, the browser still composites this layer every frame. If there are many sub-blocks with complex overlays, this adds compositor overhead over the canvas.
+
+**To verify:** Temporarily remove the overlay container and test drawing latency. Check Chrome DevTools → Layers panel for unnecessary compositing layers.
+
+**Fix options:**
+- Hide overlay entirely during active drawing (set `display: none` on pointerdown, restore on pointerup)
+- Move sub-block rendering into the canvas itself (eliminate DOM overlay)
+
+### 3. Per-event `ctx.stroke()` calls
+Each pointer move event does a full `beginPath/moveTo/lineTo/stroke` cycle. On a high-frequency stylus (Apple Pencil 240Hz, Surface Pen 120Hz), this can mean 120-240 `stroke()` calls per second. Each `stroke()` forces the browser to flush the canvas drawing pipeline.
+
+**To verify:** Profile with Chrome DevTools → Performance tab. Look for `CanvasRenderingContext2D.stroke` taking significant time.
+
+**Fix options:**
+- Batch draw commands and only call `stroke()` once per `requestAnimationFrame`
+- Accumulate points in the fast path, render them all in a single rAF callback:
+```typescript
+// In handlePointerMove: just accumulate points
+pendingPointsRef.current.push(...newPoints)
+if (!rafPendingRef.current) {
+  rafPendingRef.current = requestAnimationFrame(() => {
+    // Draw all accumulated segments in one stroke() call
+    const pts = pendingPointsRef.current
+    ctx.beginPath()
+    ctx.moveTo(pts[0].x, pts[0].y)
+    for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y)
+    ctx.stroke()
+    pendingPointsRef.current = []
+    rafPendingRef.current = null
+  })
+}
+```
+
+### 4. Pressure-based lineWidth changes per segment
+`ctx.lineWidth = baseWidth * (0.3 + p0 * 1.2)` changes for each coalesced event group. Changing `lineWidth` between segments may prevent the browser from batching GPU draw calls internally.
+
+**To verify:** Temporarily use a fixed lineWidth and compare latency.
+
+**Fix options:**
+- Use a fixed lineWidth during the fast path, only apply pressure variation in the final redraw
+- Group consecutive points with similar pressure and draw them in a single stroke
+
+### 5. `getPoint()` screen-to-logical conversion overhead
+Each coalesced event calls `getPoint()` which calls `screenToLogical()`. This is simple math but happens for every event (potentially 4-8x per pointermove).
+
+**Likely not the bottleneck** but can be inlined for zero overhead:
+```typescript
+const invScale = 1 / scaleRef.current
+const panX = panXRef.current
+const panY = panYRef.current
+for (const ce of coalescedEvents) {
+  const sx = ce.clientX - rect.left
+  const sy = ce.clientY - rect.top
+  points.push({
+    x: (sx - panX) * invScale,
+    y: (sy - panY) * invScale,
+    pressure: ce.pressure,
+    tiltX: ce.tiltX,
+    tiltY: ce.tiltY,
+    timestamp: ce.timeStamp,
+  })
+}
+```
+
+### 6. Full redraw on `handlePointerUp`
+When the pen lifts, `redraw()` re-renders ALL completed strokes via the offscreen buffer (if dirty), then blits to the visible canvas. For many strokes this could cause a visible pause at the end of each stroke.
+
+**To verify:** Add a `performance.now()` measurement around the `redraw()` call in `handlePointerUp`.
+
+**Fix options:**
+- Keep the incremental canvas state and only do a full redraw when zoom/pan changes
+- On pointerUp, just add the completed stroke to the buffer without clearing the visible canvas
+
+### 7. `cachedRectRef` might be null
+If `cachedRectRef.current` is null (e.g. before first resize observer callback), `getPoint()` falls back to `canvas.getBoundingClientRect()` which forces a synchronous layout recalculation. This is expensive and would stall the hot path.
+
+**To verify:** Add a console.warn when the fallback is hit.
+
+**Fix:** Ensure `cachedRectRef` is populated before any pointer events can fire (initialize it eagerly in the mount effect).
+
+### 8. Event listener re-attachment during drawing
+If any `useCallback` dependency is accidentally unstable, the `useEffect` re-runs mid-stroke, removing and re-adding listeners. This could cause dropped frames or lost events.
+
+**To verify:** Add a `console.log('listeners reattached')` in the useEffect body and check if it fires during drawing.
+
+---
+
+## Recommended Investigation Order
+
+1. **Check `desynchronized` is actually active** (quick, high impact if it's falling back)
+2. **Profile `ctx.stroke()` frequency** in DevTools Performance tab (identifies if per-event drawing is the bottleneck)
+3. **Test with overlay hidden** during drawing (identifies DOM compositing overhead)
+4. **Batch draws to rAF** if #2 shows stroke() overhead (likely highest-impact code change)
+5. **Measure `redraw()` duration** on pointerUp (identifies end-of-stroke pause)
+6. **Check `cachedRectRef` fallback** frequency (quick fix if it's firing)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,183 @@
+# Block-Based Pen Interpretation System — Implementation Plan
+
+## Concept
+
+The canvas becomes the primary container. When you lasso-select pen strokes and create a block, those strokes are **extracted into a sub-block** positioned at their original canvas location. Each sub-block supports **multiple variations** (original pen, interpreted text, visual interpretation, meeting notes) that you can flip between with a page-fold transition. Sub-blocks are draggable, interpretable, editable, and copyable entities on the free-form canvas.
+
+---
+
+## Phase 1: Data Model (`models.ts`, `cardBlocks.ts`)
+
+**New types in `models.ts`:**
+
+```typescript
+type VariationType = 'strokes' | 'readText' | 'interpret' | 'meetingNotes'
+
+interface SubBlockVariation {
+  id: string
+  type: VariationType
+  strokes?: PenStroke[]           // For 'strokes' type (original pen)
+  markdown?: string               // For 'readText' type
+  interpretation?: CanvasInterpretation  // For 'interpret' type
+  meetingNotes?: MeetingNotesResult      // For 'meetingNotes' type
+  createdAt: string
+}
+
+interface SubBlock {
+  id: string
+  x: number        // Logical canvas coordinates
+  y: number
+  width: number
+  height: number
+  variations: SubBlockVariation[]  // Index 0 is always original strokes
+  activeVariationIndex: number
+}
+```
+
+**Extend `ContentBlock`:**
+```typescript
+interface ContentBlock {
+  id: string
+  type: SectionType
+  textContent: string
+  drawingContent: PenStroke[]
+  subBlocks?: SubBlock[]           // NEW — sub-blocks within this canvas
+}
+```
+
+**New helpers in `cardBlocks.ts`:**
+- `nextSubBlockId()` — generates IDs with `sb_` prefix
+- `computeStrokeBounds(strokes)` — AABB with padding
+- `createSubBlockFromStrokes(strokes)` — builds sub-block with stroke variation at index 0
+
+No database schema changes needed — sub-blocks serialize as part of the existing `bodyText` JSON.
+
+---
+
+## Phase 2: Lasso → Create Sub-Block (`PenCanvas.tsx`)
+
+**Extend `PenCanvasHandle`:**
+- `getSelectedStrokes()` — returns deep-cloned selected strokes + bounds, removes them from `strokesRef`, pushes undo action, clears selection
+
+**New props on `PenCanvasProps`:**
+- `onCreateSubBlock?: (data: { strokes: PenStroke[]; bounds }) => void`
+- `onTransformChange?: (scale: number, panX: number, panY: number) => void`
+
+**Triggers for sub-block creation:**
+1. **Floating button** — "Create Block" button positioned near the lasso selection bounds
+2. **Keyboard shortcut** — `Ctrl+B` when lasso selection is active
+3. **Context menu** — "Create Block" item in the firm-press context menu
+
+---
+
+## Phase 3: Sub-Block State in SectionBlock (`CardEditor.tsx`)
+
+- Add `subBlocks` state to `SectionBlock`
+- Handle `onCreateSubBlock` callback: call `createSubBlockFromStrokes()`, append to state
+- Bubble changes up via `onSubBlocksChange` prop to `CardEditor` for persistence/auto-save
+- Track canvas transform via `onTransformChange` to position overlays correctly
+
+---
+
+## Phase 4: SubBlockOverlay Component (NEW: `SubBlockOverlay.tsx`)
+
+A positioned `<div>` overlay rendered on top of the canvas:
+
+- **Position**: `absolute`, coordinates = `subBlock.x * scale + panX`, etc.
+- **Content rendering** based on active variation type:
+  - `strokes` → `StrokePreview` component
+  - `readText` → `MarkdownPreview` component
+  - `interpret` → items/relationships summary
+  - `meetingNotes` → formatted meeting notes
+- **Drag handle** at top (captures pointer events, prevents canvas drawing)
+- **Variation switcher** — dots/tabs at bottom showing each variation
+- **Toolbar** — appears on hover/select with interpret actions
+- **Pointer events**: overlay container is `pointer-events: none`, individual sub-blocks are `pointer-events: auto`
+
+**Rendering structure in SectionBlock:**
+```tsx
+<div style={{ position: 'relative' }}>
+  <PenCanvas ... />
+  <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+    {subBlocks.map(sb => <SubBlockOverlay key={sb.id} ... />)}
+  </div>
+</div>
+```
+
+---
+
+## Phase 5: Sub-Block Dragging (`SubBlockOverlay.tsx`)
+
+- Drag handle captures `pointerdown` + `stopPropagation()`
+- `pointermove` computes delta in logical coords (screen delta / scale)
+- `pointerup` commits position via callback
+- Only the drag handle is draggable (not the whole area) to avoid pen conflicts
+
+---
+
+## Phase 6: Variation Switching with Page-Fold Transition (`app.css`, `SubBlockOverlay.tsx`)
+
+**CSS**: `perspective` + `rotateY` transforms
+- Exiting: 0° → 90° (250ms)
+- Entering: -90° → 0° (250ms)
+- `backface-visibility: hidden`
+
+**State**: `displayedIndex` + `transitioning` flag to prevent rapid switching
+
+**UI**: Dots per variation, labels on hover (Original, Text, Visual, Notes)
+
+---
+
+## Phase 7: Sub-Block Interpretation (`SubBlockOverlay.tsx` / `SectionBlock`)
+
+1. Get strokes from `variations[0].strokes`
+2. Render to offscreen canvas (reuse existing pattern from `handleInterpret`)
+3. Call existing API:
+   - `interpretCanvas(dataUrl, cardId, 'readText', blockId:subBlockId)` for text
+   - `interpretCanvas(dataUrl, cardId, undefined, blockId:subBlockId)` for visual
+   - `writeMeetingNotes(dataUrl, '', cardId)` for meeting notes
+4. Create `SubBlockVariation` with result
+5. Replace existing variation of same type, or append
+6. Switch to new variation (triggers page-fold)
+
+No server changes needed — existing endpoints accept arbitrary `blockId` strings.
+
+---
+
+## Phase 8: Sub-Block Operations
+
+| Operation | Behavior |
+|-----------|----------|
+| **Delete** | Remove sub-block, re-insert original strokes back into parent block |
+| **Copy** | Store full `SubBlock` in module-level clipboard |
+| **Paste** | Deep-clone with new ID, offset position by 20px |
+| **Reinterpret** | Re-run interpretation, replace existing variation of that type |
+
+**Keyboard shortcuts** (when sub-block is selected):
+- `Delete`/`Backspace`: delete
+- `Ctrl+C` / `Ctrl+V`: copy / paste
+- `Escape`: deselect
+- Arrow keys: nudge position (1px, 10px with Shift)
+
+---
+
+## Phase 9: Polish & Edge Cases
+
+- Clamp sub-blocks to stay within visible canvas area
+- Minimum sub-block size of 40×40px
+- Empty sub-block placeholder (if strokes erased)
+- Inactive SectionBlock: composite sub-block strokes back for StrokePreview
+- Draft persistence: include sub-blocks in localStorage drafts
+
+---
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `client/src/types/models.ts` | Add `SubBlock`, `SubBlockVariation`, `VariationType`; extend `ContentBlock` |
+| `client/src/utils/cardBlocks.ts` | Add `createSubBlockFromStrokes`, `computeStrokeBounds`, `nextSubBlockId` |
+| `client/src/components/PenCanvas.tsx` | Add `getSelectedStrokes`, `onCreateSubBlock`, `onTransformChange` props, "Create Block" trigger |
+| `client/src/components/CardEditor.tsx` | Sub-block state in SectionBlock, overlay container, creation/interpret/delete callbacks |
+| `client/src/components/SubBlockOverlay.tsx` | **NEW** — overlay rendering, drag, variation display, page-fold, interpret toolbar |
+| `client/src/styles/app.css` | Page-fold transition CSS classes |


### PR DESCRIPTION
Introduces a sub-block system where lasso-selected pen strokes can be
extracted into positioned, draggable blocks on the canvas. Each sub-block
supports multiple variations (original pen, interpreted text, visual
interpretation, meeting notes) with a page-fold CSS transition when
switching between them. Sub-blocks persist as part of the ContentBlock
JSON and are rendered as overlays on the PenCanvas.

Key changes:
- New SubBlock, SubBlockVariation, VariationType types in models.ts
- createSubBlockFromStrokes/computeStrokeBounds helpers in cardBlocks.ts
- PenCanvas: extractSelection, onCreateSubBlock, onTransformChange props,
  "Create Block" in context menu and Ctrl+B shortcut
- SubBlockOverlay component with drag, interpret, variation switching
- CardEditor/SectionBlock: sub-block state management and rendering
- Page-fold animation CSS and sub-block preview cards for inactive view

https://claude.ai/code/session_019QTARwgseDsSQo7dxjvuf5